### PR TITLE
Massive code and docs cleanup

### DIFF
--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/callbacks/ContactFilter.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/callbacks/ContactFilter.kt
@@ -26,10 +26,8 @@
  */
 package org.jbox2d.callbacks
 
-import org.jbox2d.dynamics.Filter
 import org.jbox2d.dynamics.Fixture
 
-// updated to rev 100
 /**
  * Implement this class to provide collision filtering. In other words, you can implement
  * this class if you want finer control over contact creation.
@@ -40,9 +38,6 @@ class ContactFilter {
     /**
      * Return true if contact calculations should be performed between these two shapes.
      * @warning for performance reasons this is only called when the AABBs begin to overlap.
-     * @param fixtureA
-     * @param fixtureB
-     * @return
      */
     fun shouldCollide(fixtureA: Fixture, fixtureB: Fixture): Boolean {
         val filterA = fixtureA.filterData

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/callbacks/ContactListener.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/callbacks/ContactListener.kt
@@ -26,7 +26,6 @@ package org.jbox2d.callbacks
 import org.jbox2d.collision.Manifold
 import org.jbox2d.dynamics.contacts.Contact
 
-// updated to rev 100
 /**
  * Implement this class to get contact information. You can use these results for
  * things like sounds and game logic. You can also get contact results by
@@ -43,44 +42,38 @@ interface ContactListener {
 
     /**
      * Called when two fixtures begin to touch.
-     * @param contact
      */
     fun beginContact(contact: Contact)
 
     /**
      * Called when two fixtures cease to touch.
-     * @param contact
      */
     fun endContact(contact: Contact)
 
     /**
      * This is called after a contact is updated. This allows you to inspect a
-     * contact before it goes to the solver. If you are careful, you can modify the
+     * [contact] before it goes to the solver. If you are careful, you can modify the
      * contact manifold (e.g. disable contact).
      * A copy of the old manifold is provided so that you can detect changes.
      * Note: this is called only for awake bodies.
      * Note: this is called even when the number of contact points is zero.
      * Note: this is not called for sensors.
      * Note: if you set the number of contact points to zero, you will not
-     * get an EndContact callback. However, you may get a BeginContact callback
+     * get an  [endContact] callback. However, you may get a [beginContact] callback
      * the next step.
-     * Note: the oldManifold parameter is pooled, so it will be the same object for every callback
+     * Note: the [oldManifold] parameter is pooled, so it will be the same object for every callback
      * for each thread.
-     * @param contact
-     * @param oldManifold
      */
     fun preSolve(contact: Contact, oldManifold: Manifold)
 
     /**
-     * This lets you inspect a contact after the solver is finished. This is useful
+     * This lets you inspect a [contact] after the solver is finished. This is useful
      * for inspecting impulses.
      * Note: the contact manifold does not include time of impact impulses, which can be
-     * arbitrarily large if the sub-step is small. Hence the impulse is provided explicitly
+     * arbitrarily large if the sub-step is small. Hence the [impulse] is provided explicitly
      * in a separate data structure.
      * Note: this is only called for contacts that are touching, solid, and awake.
-     * @param contact
-     * @param impulse this is usually a pooled variable, so it will be modified after
-     * this call
+     * Note: [impulse] is usually a pooled variable, so it will be modified after this call
      */
     fun postSolve(contact: Contact, impulse: ContactImpulse)
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/callbacks/DebugDraw.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/callbacks/DebugDraw.kt
@@ -38,17 +38,11 @@ import org.jbox2d.particle.ParticleColor
  *
  * @author Daniel Murphy
  */
-abstract class DebugDraw  constructor(viewport: IViewportTransform? = null) {
-
+abstract class DebugDraw(viewport: IViewportTransform? = null) {
 
     var flags: Int = 0
-    var viewportTranform: IViewportTransform? = null
+    var viewportTranform: IViewportTransform? = viewport
         protected set
-
-    init {
-        flags = 0
-        viewportTranform = viewport
-    }
 
     fun setViewportTransform(viewportTransform: IViewportTransform) {
         this.viewportTranform = viewportTransform
@@ -64,11 +58,7 @@ abstract class DebugDraw  constructor(viewport: IViewportTransform? = null) {
 
     /**
      * Draw a closed polygon provided in CCW order. This implementation uses
-     * [.drawSegment] to draw each side of the polygon.
-     *
-     * @param vertices
-     * @param vertexCount
-     * @param color
+     * [drawSegment] to draw each side of the polygon.
      */
     fun drawPolygon(vertices: Array<Vec2>, vertexCount: Int, color: Color3f) {
         if (vertexCount == 1) {
@@ -89,79 +79,34 @@ abstract class DebugDraw  constructor(viewport: IViewportTransform? = null) {
 
     abstract fun drawPoint(argPoint: Vec2, argRadiusOnScreen: Float, argColor: Color3f)
 
-    /**
-     * Draw a solid closed polygon provided in CCW order.
-     *
-     * @param vertices
-     * @param vertexCount
-     * @param color
-     */
+    /** Draw a solid closed polygon provided in CCW order. */
     abstract fun drawSolidPolygon(vertices: Array<Vec2>, vertexCount: Int, color: Color3f)
 
-    /**
-     * Draw a circle.
-     *
-     * @param center
-     * @param radius
-     * @param color
-     */
+    /** Draw a circle. */
     abstract fun drawCircle(center: Vec2, radius: Float, color: Color3f)
 
-    /** Draws a circle with an axis  */
+    /** Draws a circle with an axis.  */
     fun drawCircle(center: Vec2, radius: Float, axis: Vec2, color: Color3f) {
         drawCircle(center, radius, color)
     }
 
-    /**
-     * Draw a solid circle.
-     *
-     * @param center
-     * @param radius
-     * @param axis
-     * @param color
-     */
+    /** Draw a solid circle. */
     abstract fun drawSolidCircle(center: Vec2, radius: Float, axis: Vec2, color: Color3f)
 
-    /**
-     * Draw a line segment.
-     *
-     * @param p1
-     * @param p2
-     * @param color
-     */
+    /** Draw a line segment. */
     abstract fun drawSegment(p1: Vec2, p2: Vec2, color: Color3f)
 
-    /**
-     * Draw a transform. Choose your own length scale
-     *
-     * @param xf
-     */
+    /** Draw a transform. Choose your own length scale */
     abstract fun drawTransform(xf: Transform)
 
-    /**
-     * Draw a string.
-     *
-     * @param x
-     * @param y
-     * @param s
-     * @param color
-     */
+    /** Draw a string. */
     abstract fun drawString(x: Float, y: Float, s: String, color: Color3f)
 
-    /**
-     * Draw a particle array
-     *
-     * @param colors can be null
-     */
-    abstract fun drawParticles(centers: Array<Vec2>, radius: Float, colors: Array<ParticleColor>, count: Int)
+    /** Draw a particle array */
+    abstract fun drawParticles(centers: Array<Vec2>, radius: Float, colors: Array<ParticleColor>?, count: Int)
 
-    /**
-     * Draw a particle array
-     *
-     * @param colors can be null
-     */
-    abstract fun drawParticlesWireframe(centers: Array<Vec2>, radius: Float, colors: Array<ParticleColor>,
-                                        count: Int)
+    /** Draw a particle array */
+    abstract fun drawParticlesWireframe(centers: Array<Vec2>, radius: Float, colors: Array<ParticleColor>?, count: Int)
 
     /** Called at the end of drawing a world  */
     fun flush() {}
@@ -170,39 +115,16 @@ abstract class DebugDraw  constructor(viewport: IViewportTransform? = null) {
         drawString(pos.x, pos.y, s, color)
     }
 
-    /**
-     * @param x
-     * @param y
-     * @param scale
-     */
-    @Deprecated("use the viewport transform in {@link #getViewportTranform()}")
-    fun setCamera(x: Float, y: Float, scale: Float) {
-        viewportTranform!!.setCamera(x, y, scale)
-    }
-
-
-    /**
-     * @param argScreen
-     * @param argWorld
-     */
     fun getScreenToWorldToOut(argScreen: Vec2, argWorld: Vec2) {
         viewportTranform!!.getScreenToWorld(argScreen, argWorld)
     }
 
-    /**
-     * @param argWorld
-     * @param argScreen
-     */
     fun getWorldToScreenToOut(argWorld: Vec2, argScreen: Vec2) {
         viewportTranform!!.getWorldToScreen(argWorld, argScreen)
     }
 
     /**
      * Takes the world coordinates and puts the corresponding screen coordinates in argScreen.
-     *
-     * @param worldX
-     * @param worldY
-     * @param argScreen
      */
     fun getWorldToScreenToOut(worldX: Float, worldY: Float, argScreen: Vec2) {
         argScreen.set(worldX, worldY)
@@ -210,9 +132,7 @@ abstract class DebugDraw  constructor(viewport: IViewportTransform? = null) {
     }
 
     /**
-     * takes the world coordinate (argWorld) and returns the screen coordinates.
-     *
-     * @param argWorld
+     * Takes the world coordinate ([argWorld]) and returns the screen coordinates.
      */
     fun getWorldToScreen(argWorld: Vec2): Vec2 {
         val screen = Vec2()
@@ -222,9 +142,6 @@ abstract class DebugDraw  constructor(viewport: IViewportTransform? = null) {
 
     /**
      * Takes the world coordinates and returns the screen coordinates.
-     *
-     * @param worldX
-     * @param worldY
      */
     fun getWorldToScreen(worldX: Float, worldY: Float): Vec2 {
         val argScreen = Vec2(worldX, worldY)
@@ -233,11 +150,7 @@ abstract class DebugDraw  constructor(viewport: IViewportTransform? = null) {
     }
 
     /**
-     * takes the screen coordinates and puts the corresponding world coordinates in argWorld.
-     *
-     * @param screenX
-     * @param screenY
-     * @param argWorld
+     * Takes the screen coordinates and puts the corresponding world coordinates in the [argWorld].
      */
     fun getScreenToWorldToOut(screenX: Float, screenY: Float, argWorld: Vec2) {
         argWorld.set(screenX, screenY)
@@ -245,9 +158,7 @@ abstract class DebugDraw  constructor(viewport: IViewportTransform? = null) {
     }
 
     /**
-     * takes the screen coordinates (argScreen) and returns the world coordinates
-     *
-     * @param argScreen
+     * Takes the screen coordinates ([argScreen]) and returns the world coordinates
      */
     fun getScreenToWorld(argScreen: Vec2): Vec2 {
         val world = Vec2()
@@ -256,10 +167,7 @@ abstract class DebugDraw  constructor(viewport: IViewportTransform? = null) {
     }
 
     /**
-     * takes the screen coordinates and returns the world coordinates.
-     *
-     * @param screenX
-     * @param screenY
+     * Takes the screen coordinates and returns the world coordinates.
      */
     fun getScreenToWorld(screenX: Float, screenY: Float): Vec2 {
         val screen = Vec2(screenX, screenY)
@@ -268,20 +176,19 @@ abstract class DebugDraw  constructor(viewport: IViewportTransform? = null) {
     }
 
     companion object {
-
         /** Draw shapes  */
-        val e_shapeBit = 1 shl 1
+        val shapeBit = 1 shl 1
         /** Draw joint connections  */
-        val e_jointBit = 1 shl 2
+        val jointBit = 1 shl 2
         /** Draw axis aligned bounding boxes  */
-        val e_aabbBit = 1 shl 3
+        val aabbBit = 1 shl 3
         /** Draw pairs of connected objects  */
-        val e_pairBit = 1 shl 4
+        val pairBit = 1 shl 4
         /** Draw center of mass frame  */
-        val e_centerOfMassBit = 1 shl 5
+        val centerOfMassBit = 1 shl 5
         /** Draw dynamic tree  */
-        val e_dynamicTreeBit = 1 shl 6
+        val dynamicTreeBit = 1 shl 6
         /** Draw only the wireframe for drawing performance  */
-        val e_wireframeDrawingBit = 1 shl 7
+        val wireframeDrawingBit = 1 shl 7
     }
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/callbacks/DestructionListener.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/callbacks/DestructionListener.kt
@@ -40,14 +40,12 @@ interface DestructionListener {
     /**
      * Called when any joint is about to be destroyed due
      * to the destruction of one of its attached bodies.
-     * @param joint
      */
     fun sayGoodbye(joint: Joint)
 
     /**
      * Called when any fixture is about to be destroyed due
      * to the destruction of its parent body.
-     * @param fixture
      */
     fun sayGoodbye(fixture: Fixture)
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/callbacks/PairCallback.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/callbacks/PairCallback.kt
@@ -23,7 +23,6 @@
  */
 package org.jbox2d.callbacks
 
-// updated to rev 100
 interface PairCallback {
     fun addPair(userDataA: Any?, userDataB: Any?)
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/callbacks/ParticleDestructionListener.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/callbacks/ParticleDestructionListener.kt
@@ -11,9 +11,7 @@ interface ParticleDestructionListener {
 
     /**
      * Called when a particle is about to be destroyed. The index can be used in conjunction with
-     * [World.getParticleUserDataBuffer] to determine which particle has been destroyed.
-     *
-     * @param index
+     * [World.particleUserDataBuffer] to determine which particle has been destroyed.
      */
     fun sayGoodbye(index: Int)
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/callbacks/ParticleQueryCallback.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/callbacks/ParticleQueryCallback.kt
@@ -11,7 +11,6 @@ import org.jbox2d.dynamics.World
 interface ParticleQueryCallback {
     /**
      * Called for each particle found in the query AABB.
-     *
      * @return false to terminate the query.
      */
     fun reportParticle(index: Int): Boolean

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/callbacks/ParticleRaycastCallback.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/callbacks/ParticleRaycastCallback.kt
@@ -4,16 +4,8 @@ import org.jbox2d.common.Vec2
 
 interface ParticleRaycastCallback {
     /**
-     * Called for each particle found in the query. See
-     * [RayCastCallback.reportFixture] for
-     * argument info.
-     *
-     * @param index
-     * @param point
-     * @param normal
-     * @param fraction
-     * @return
+     * Called for each particle found in the query.
+     * See [RayCastCallback.reportFixture] for  argument info.
      */
     fun reportParticle(index: Int, point: Vec2, normal: Vec2, fraction: Float): Float
-
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/callbacks/QueryCallback.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/callbacks/QueryCallback.kt
@@ -30,15 +30,14 @@ import org.jbox2d.dynamics.Fixture
 import org.jbox2d.dynamics.World
 
 /**
- * Callback class for AABB queries.
+ * Callback class for [AABB] queries.
  * See [World.queryAABB].
  * @author Daniel Murphy
  */
 interface QueryCallback {
 
     /**
-     * Called for each fixture found in the query AABB.
-     * @param fixture
+     * Called for each fixture found in the query [AABB].
      * @return false to terminate the query.
      */
     fun reportFixture(fixture: Fixture): Boolean

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/callbacks/RayCastCallback.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/callbacks/RayCastCallback.kt
@@ -40,16 +40,17 @@ interface RayCastCallback {
     /**
      * Called for each fixture found in the query. You control how the ray cast
      * proceeds by returning a float:
-     * return -1: ignore this fixture and continue
-     * return 0: terminate the ray cast
-     * return fraction: clip the ray to this point
-     * return 1: don't clip the ray and continue
+     * - return -1: ignore this fixture and continue
+     * - return 0: terminate the ray cast
+     * - return [fraction]: clip the ray to this point
+     * - return 1: don't clip the ray and continue
+     *
      * @param fixture the fixture hit by the ray
      * @param point the point of initial intersection
      * @param normal the normal vector at the point of intersection
-     * @return -1 to filter, 0 to terminate, fraction to clip the ray for
+     *
+     * @return -1 to filter, 0 to terminate, [fraction] to clip the ray for
      * closest hit, 1 to continue
-     * @param fraction
      */
     fun reportFixture(fixture: Fixture, point: Vec2, normal: Vec2, fraction: Float): Float
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/callbacks/TreeCallback.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/callbacks/TreeCallback.kt
@@ -25,17 +25,15 @@ package org.jbox2d.callbacks
 
 import org.jbox2d.collision.broadphase.DynamicTree
 
-// update to rev 100
 /**
- * callback for [DynamicTree]
+ * Callback for [DynamicTree]
  * @author Daniel Murphy
  */
 interface TreeCallback {
 
     /**
      * Callback from a query request.
-     * @param proxyId the id of the proxy
-     * @return if the query should be continued
+     * @return true if the query should be continued
      */
     fun treeCallback(proxyId: Int): Boolean
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/callbacks/TreeRayCastCallback.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/callbacks/TreeRayCastCallback.kt
@@ -26,17 +26,12 @@ package org.jbox2d.callbacks
 import org.jbox2d.collision.RayCastInput
 import org.jbox2d.collision.broadphase.DynamicTree
 
-// updated to rev 100
-
 /**
  * callback for [DynamicTree]
  * @author Daniel Murphy
  */
 interface TreeRayCastCallback {
     /**
-     *
-     * @param input
-     * @param nodeId
      * @return the fraction to the node
      */
     fun raycastCallback(input: RayCastInput, nodeId: Int): Float

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/AABB.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/AABB.kt
@@ -31,30 +31,24 @@ import org.jbox2d.pooling.normal.DefaultWorldPool
 
 /** An axis-aligned bounding box.  */
 class AABB {
-    /** Bottom left vertex of bounding box.  */
 
+    /** Bottom left vertex of bounding box. */
     val lowerBound: Vec2
-    /** Top right vertex of bounding box.  */
 
+    /** Top right vertex of bounding box. */
     val upperBound: Vec2
 
-    /** Verify that the bounds are sorted  */
+    /** Verify that the bounds are sorted */
     val isValid: Boolean
         get() {
             val dx = upperBound.x - lowerBound.x
-            if (dx < 0f) {
-                return false
-            }
+            if (dx < 0) return false
             val dy = upperBound.y - lowerBound.y
-            return if (dy < 0) {
-                false
-            } else lowerBound.isValid && upperBound.isValid
+            return if (dy < 0) false else lowerBound.isValid && upperBound.isValid
         }
 
     /**
-     * Get the center of the AABB
-     *
-     * @return
+     * Center of the AABB
      */
     val center: Vec2
         get() {
@@ -65,9 +59,7 @@ class AABB {
         }
 
     /**
-     * Get the extents of the AABB (half-widths).
-     *
-     * @return
+     * Extents of the AABB (half-widths).
      */
     val extents: Vec2
         get() {
@@ -78,33 +70,26 @@ class AABB {
         }
 
     /**
-     * Gets the perimeter length
-     *
-     * @return
+     * Perimeter length
      */
     val perimeter: Float
         get() = 2.0f * (upperBound.x - lowerBound.x + upperBound.y - lowerBound.y)
 
     /**
-     * Creates the default object, with vertices at 0,0 and 0,0.
+     * Creates a default object, with vertices at 0,0 and 0,0.
      */
-    constructor() {
-        lowerBound = Vec2()
-        upperBound = Vec2()
-    }
+    constructor() : this(Vec2(), Vec2())
 
     /**
-     * Copies from the given object
-     *
-     * @param copy the object to copy from
+     * Copies from the [copy] object
      */
-    constructor(copy: AABB) : this(copy.lowerBound, copy.upperBound) {}
+    constructor(copy: AABB) : this(copy.lowerBound, copy.upperBound)
 
     /**
      * Creates an AABB object using the given bounding vertices.
      *
      * @param lowerVertex the bottom left vertex of the bounding box
-     * @param maxVertex the top right vertex of the bounding box
+     * @param upperVertex the top right vertex of the bounding box
      */
     constructor(lowerVertex: Vec2, upperVertex: Vec2) {
         this.lowerBound = lowerVertex.clone() // clone to be safe
@@ -112,9 +97,7 @@ class AABB {
     }
 
     /**
-     * Sets this object from the given object
-     *
-     * @param aabb the object to copy from
+     * Sets this object from the [aabb] object
      */
     fun set(aabb: AABB) {
         val v = aabb.lowerBound
@@ -146,9 +129,6 @@ class AABB {
 
     /**
      * Combine two AABBs into this one.
-     *
-     * @param aabb1
-     * @param aab
      */
     fun combine(aabb1: AABB, aab: AABB) {
         lowerBound.x = if (aabb1.lowerBound.x < aab.lowerBound.x) aabb1.lowerBound.x else aab.lowerBound.x
@@ -158,9 +138,7 @@ class AABB {
     }
 
     /**
-     * Combines another aabb with this one
-     *
-     * @param aabb
+     * Combines another [aabb] with this one
      */
     fun combine(aabb: AABB) {
         lowerBound.x = if (lowerBound.x < aabb.lowerBound.x) lowerBound.x else aabb.lowerBound.x
@@ -170,31 +148,21 @@ class AABB {
     }
 
     /**
-     * Does this aabb contain the provided AABB.
-     *
-     * @return
+     * Whether this AABB contain the provided [aabb].
      */
     operator fun contains(aabb: AABB): Boolean {
-        /*
-     * boolean result = true; result = result && lowerBound.x <= aabb.lowerBound.x; result = result
-     * && lowerBound.y <= aabb.lowerBound.y; result = result && aabb.upperBound.x <= upperBound.x;
-     * result = result && aabb.upperBound.y <= upperBound.y; return result;
-     */
-        // djm: faster putting all of them together, as if one is false we leave the logic
-        // early
-        return (lowerBound.x <= aabb.lowerBound.x && lowerBound.y <= aabb.lowerBound.y
-                && aabb.upperBound.x <= upperBound.x && aabb.upperBound.y <= upperBound.y)
+        return lowerBound.x <= aabb.lowerBound.x && lowerBound.y <= aabb.lowerBound.y
+            && aabb.upperBound.x <= upperBound.x && aabb.upperBound.y <= upperBound.y
     }
 
     /**
      * From Real-time Collision Detection, p179.
-     *
-     * @param output
-     * @param input
      */
-
-    fun raycast(output: RayCastOutput, input: RayCastInput,
-                argPool: IWorldPool = DefaultWorldPool(4, 4)): Boolean {
+    fun raycast(
+        output: RayCastOutput,
+        input: RayCastInput,
+        argPool: IWorldPool = DefaultWorldPool(4, 4)
+    ): Boolean {
         var tmin = -Float.MAX_VALUE
         var tmax = Float.MAX_VALUE
 
@@ -297,26 +265,14 @@ class AABB {
         return true
     }
 
-    override fun toString(): String {
-        val s = "AABB[$lowerBound . $upperBound]"
-        return s
-    }
+    override fun toString() = "AABB[$lowerBound . $upperBound]"
 
     companion object {
         fun testOverlap(a: AABB, b: AABB): Boolean {
             if (b.lowerBound.x - a.upperBound.x > 0.0f || b.lowerBound.y - a.upperBound.y > 0.0f) {
                 return false
             }
-
-            return if (a.lowerBound.x - b.upperBound.x > 0.0f || a.lowerBound.y - b.upperBound.y > 0.0f) {
-                false
-            } else true
-
+            return !(a.lowerBound.x - b.upperBound.x > 0.0f || a.lowerBound.y - b.upperBound.y > 0.0f)
         }
     }
 }
-/**
- * @param output
- * @param input
- * @return
- */

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/Collision.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/Collision.kt
@@ -29,12 +29,8 @@ import org.jbox2d.collision.shapes.CircleShape
 import org.jbox2d.collision.shapes.EdgeShape
 import org.jbox2d.collision.shapes.PolygonShape
 import org.jbox2d.collision.shapes.Shape
-import org.jbox2d.common.MathUtils
-import org.jbox2d.common.Rot
-import org.jbox2d.common.Settings
-import org.jbox2d.common.Transform
-import org.jbox2d.common.Vec2
-import org.jbox2d.internal.*
+import org.jbox2d.common.*
+import org.jbox2d.internal.assert
 import org.jbox2d.pooling.IWorldPool
 
 /**
@@ -58,15 +54,15 @@ class Collision(private val pool: IWorldPool) {
 
     private val results1 = EdgeResults()
     private val results2 = EdgeResults()
-    private val incidentEdge = Array<ClipVertex>(2) { ClipVertex() }
+    private val incidentEdge = Array(2) { ClipVertex() }
     private val localTangent = Vec2()
     private val localNormal = Vec2()
     private val planePoint = Vec2()
     private val tangent = Vec2()
     private val v11 = Vec2()
     private val v12 = Vec2()
-    private val clipPoints1 = Array<ClipVertex>(2) { ClipVertex() }
-    private val clipPoints2 = Array<ClipVertex>(2) { ClipVertex() }
+    private val clipPoints1 = Array(2) { ClipVertex() }
+    private val clipPoints2 = Array(2) { ClipVertex() }
 
     private val Q = Vec2()
     private val e = Vec2()
@@ -76,17 +72,16 @@ class Collision(private val pool: IWorldPool) {
 
     private val collider = EPCollider()
 
+    // djm pooling
+    private val d = Vec2()
+
     /**
      * Determine if two generic shapes overlap.
-     *
-     * @param shapeA
-     * @param shapeB
-     * @param xfA
-     * @param xfB
-     * @return
      */
-    fun testOverlap(shapeA: Shape, indexA: Int, shapeB: Shape, indexB: Int,
-                    xfA: Transform, xfB: Transform): Boolean {
+    fun testOverlap(
+        shapeA: Shape, indexA: Int, shapeB: Shape, indexB: Int,
+        xfA: Transform, xfB: Transform
+    ): Boolean {
         input.proxyA.set(shapeA, indexA)
         input.proxyB.set(shapeB, indexB)
         input.transformA.set(xfA)
@@ -101,16 +96,12 @@ class Collision(private val pool: IWorldPool) {
     }
 
     /**
-     * Compute the collision manifold between two circles.
-     *
-     * @param manifold
-     * @param circle1
-     * @param xfA
-     * @param circle2
-     * @param xfB
+     * Compute the collision [manifold] between two circles.
      */
-    fun collideCircles(manifold: Manifold, circle1: CircleShape,
-                       xfA: Transform, circle2: CircleShape, xfB: Transform) {
+    fun collideCircles(
+        manifold: Manifold, circle1: CircleShape,
+        xfA: Transform, circle2: CircleShape, xfB: Transform
+    ) {
         manifold.pointCount = 0
         // before inline:
         // Transform.mulToOut(xfA, circle1.m_p, pA);
@@ -119,8 +110,8 @@ class Collision(private val pool: IWorldPool) {
         // float distSqr = d.x * d.x + d.y * d.y;
 
         // after inline:
-        val circle1p = circle1.m_p
-        val circle2p = circle2.m_p
+        val circle1p = circle1.p
+        val circle2p = circle2.p
         val pAx = xfA.q.c * circle1p.x - xfA.q.s * circle1p.y + xfA.p.x
         val pAy = xfA.q.s * circle1p.x + xfA.q.c * circle1p.y + xfA.p.y
         val pBx = xfB.q.c * circle2p.x - xfB.q.s * circle2p.y + xfB.p.x
@@ -130,10 +121,8 @@ class Collision(private val pool: IWorldPool) {
         val distSqr = dx * dx + dy * dy
         // end inline
 
-        val radius = circle1.m_radius + circle2.m_radius
-        if (distSqr > radius * radius) {
-            return
-        }
+        val radius = circle1.radius + circle2.radius
+        if (distSqr > radius * radius) return
 
         manifold.type = ManifoldType.CIRCLES
         manifold.localPoint.set(circle1p)
@@ -147,16 +136,12 @@ class Collision(private val pool: IWorldPool) {
     // djm pooling, and from above
 
     /**
-     * Compute the collision manifold between a polygon and a circle.
-     *
-     * @param manifold
-     * @param polygon
-     * @param xfA
-     * @param circle
-     * @param xfB
+     * Compute the collision [manifold] between a [polygon] and a [circle].
      */
-    fun collidePolygonAndCircle(manifold: Manifold, polygon: PolygonShape,
-                                xfA: Transform, circle: CircleShape, xfB: Transform) {
+    fun collidePolygonAndCircle(
+        manifold: Manifold, polygon: PolygonShape,
+        xfA: Transform, circle: CircleShape, xfB: Transform
+    ) {
         manifold.pointCount = 0
         // Vec2 v = circle.m_p;
 
@@ -167,7 +152,7 @@ class Collision(private val pool: IWorldPool) {
         // final float cLocalx = cLocal.x;
         // final float cLocaly = cLocal.y;
         // after inline:
-        val circlep = circle.m_p
+        val circlep = circle.p
         val xfBq = xfB.q
         val xfAq = xfA.q
         val cx = xfBq.c * circlep.x - xfBq.s * circlep.y + xfB.p.x
@@ -181,11 +166,11 @@ class Collision(private val pool: IWorldPool) {
         // Find the min separating edge.
         var normalIndex = 0
         var separation = -Float.MAX_VALUE
-        val radius = polygon.m_radius + circle.m_radius
-        val vertexCount = polygon.m_count
+        val radius = polygon.radius + circle.radius
+        val vertexCount = polygon.vertexCount
         var s: Float
-        val vertices = polygon.m_vertices
-        val normals = polygon.m_normals
+        val vertices = polygon.vertices
+        val normals = polygon.normals
 
         for (i in 0 until vertexCount) {
             // before inline
@@ -197,11 +182,8 @@ class Collision(private val pool: IWorldPool) {
             val tempy = cLocaly - vertex.y
             s = normals[i].x * tempx + normals[i].y * tempy
 
-
-            if (s > radius) {
-                // early out
-                return
-            }
+            // early out
+            if (s > radius) return
 
             if (s > separation) {
                 separation = s
@@ -338,22 +320,17 @@ class Collision(private val pool: IWorldPool) {
     private val poolVec2 = Vec2()
 
     /**
-     * Find the max separation between poly1 and poly2 using edge normals from poly1.
-     *
-     * @param edgeIndex
-     * @param poly1
-     * @param xf1
-     * @param poly2
-     * @param xf2
-     * @return
+     * Find the max separation between [poly1] and [poly2] using edge normals from [poly1].
      */
-    fun findMaxSeparation(results: EdgeResults, poly1: PolygonShape,
-                          xf1: Transform, poly2: PolygonShape, xf2: Transform) {
-        val count1 = poly1.m_count
-        val count2 = poly2.m_count
-        val n1s = poly1.m_normals
-        val v1s = poly1.m_vertices
-        val v2s = poly2.m_vertices
+    fun findMaxSeparation(
+        results: EdgeResults, poly1: PolygonShape, xf1: Transform,
+        poly2: PolygonShape, xf2: Transform
+    ) {
+        val count1 = poly1.vertexCount
+        val count2 = poly2.vertexCount
+        val n1s = poly1.normals
+        val v1s = poly1.vertices
+        val v2s = poly2.vertices
 
         Transform.mulTransToOutUnsafe(xf2, xf1, xf, poolVec2)
         val xfq = xf.q
@@ -385,14 +362,16 @@ class Collision(private val pool: IWorldPool) {
         results.separation = maxSeparation
     }
 
-    fun findIncidentEdge(c: Array<ClipVertex>, poly1: PolygonShape,
-                         xf1: Transform, edge1: Int, poly2: PolygonShape, xf2: Transform) {
-        val count1 = poly1.m_count
-        val normals1 = poly1.m_normals
+    fun findIncidentEdge(
+        c: Array<ClipVertex>, poly1: PolygonShape, xf1: Transform,
+        edge1: Int, poly2: PolygonShape, xf2: Transform
+    ) {
+        val count1 = poly1.vertexCount
+        val normals1 = poly1.normals
 
-        val count2 = poly2.m_count
-        val vertices2 = poly2.m_vertices
-        val normals2 = poly2.m_normals
+        val count2 = poly2.vertexCount
+        val vertices2 = poly2.vertices
+        val normals2 = poly2.normals
 
         assert(0 <= edge1 && edge1 < count1)
 
@@ -454,15 +433,11 @@ class Collision(private val pool: IWorldPool) {
 
     /**
      * Compute the collision manifold between two polygons.
-     *
-     * @param manifold
-     * @param polygon1
-     * @param xf1
-     * @param polygon2
-     * @param xf2
      */
-    fun collidePolygons(manifold: Manifold, polyA: PolygonShape,
-                        xfA: Transform, polyB: PolygonShape, xfB: Transform) {
+    fun collidePolygons(
+        manifold: Manifold, polyA: PolygonShape,
+        xfA: Transform, polyB: PolygonShape, xfB: Transform
+    ) {
         // Find edge normal of max separation on A - return if separating axis is found
         // Find edge normal of max separation on B - return if separation axis is found
         // Choose reference edge as min(minA, minB)
@@ -472,7 +447,7 @@ class Collision(private val pool: IWorldPool) {
         // The normal points from 1 to 2
 
         manifold.pointCount = 0
-        val totalRadius = polyA.m_radius + polyB.m_radius
+        val totalRadius = polyA.radius + polyB.radius
 
         findMaxSeparation(results1, polyA, xfA, polyB, xfB)
         if (results1.separation > totalRadius) {
@@ -488,7 +463,7 @@ class Collision(private val pool: IWorldPool) {
         val poly2: PolygonShape  // incident polygon
         val xf1: Transform
         val xf2: Transform
-        val edge1: Int                 // reference edge
+        val edge1: Int           // reference edge
         val flip: Boolean
         val k_tol = 0.1f * Settings.linearSlop
 
@@ -513,8 +488,8 @@ class Collision(private val pool: IWorldPool) {
 
         findIncidentEdge(incidentEdge, poly1, xf1, edge1, poly2, xf2)
 
-        val count1 = poly1.m_count
-        val vertices1 = poly1.m_vertices
+        val count1 = poly1.vertexCount
+        val vertices1 = poly1.vertices
 
         val iv1 = edge1
         val iv2 = if (edge1 + 1 < count1) edge1 + 1 else 0
@@ -567,16 +542,12 @@ class Collision(private val pool: IWorldPool) {
         np = clipSegmentToLine(clipPoints1, incidentEdge, tangent, sideOffset1, iv1)
         tangent.negateLocal()
 
-        if (np < 2) {
-            return
-        }
+        if (np < 2) return
 
         // Clip to negative box side 1
         np = clipSegmentToLine(clipPoints2, clipPoints1, tangent, sideOffset2, iv2)
 
-        if (np < 2) {
-            return
-        }
+        if (np < 2) return
 
         // Now clipPoints2 contains the clipped points.
         manifold.localNormal.set(localNormal)
@@ -609,25 +580,26 @@ class Collision(private val pool: IWorldPool) {
 
     // Compute contact points for edge versus circle.
     // This accounts for edge connectivity.
-    fun collideEdgeAndCircle(manifold: Manifold, edgeA: EdgeShape, xfA: Transform,
-                             circleB: CircleShape, xfB: Transform) {
+    fun collideEdgeAndCircle(
+        manifold: Manifold, edgeA: EdgeShape, xfA: Transform,
+        circleB: CircleShape, xfB: Transform
+    ) {
         manifold.pointCount = 0
-
 
         // Compute circle in frame of edge
         // Vec2 Q = MulT(xfA, Mul(xfB, circleB.m_p));
-        Transform.mulToOutUnsafe(xfB, circleB.m_p, temp)
+        Transform.mulToOutUnsafe(xfB, circleB.p, temp)
         Transform.mulTransToOutUnsafe(xfA, temp, Q)
 
-        val A = edgeA.m_vertex1
-        val B = edgeA.m_vertex2
+        val A = edgeA.vertex1
+        val B = edgeA.vertex2
         e.set(B).subLocal(A)
 
         // Barycentric coordinates
         val u = Vec2.dot(e, temp.set(B).subLocal(Q))
         val v = Vec2.dot(e, temp.set(Q).subLocal(A))
 
-        val radius = edgeA.m_radius + circleB.m_radius
+        val radius = edgeA.radius + circleB.radius
 
         // ContactFeature cf;
         cf.indexB = 0
@@ -638,21 +610,17 @@ class Collision(private val pool: IWorldPool) {
             val P = A
             d.set(Q).subLocal(P)
             val dd = Vec2.dot(d, d)
-            if (dd > radius * radius) {
-                return
-            }
+            if (dd > radius * radius) return
 
             // Is there an edge connected to A?
-            if (edgeA.m_hasVertex0) {
-                val A1 = edgeA.m_vertex0
+            if (edgeA.hasVertex0) {
+                val A1 = edgeA.vertex0
                 val B1 = A
                 e1.set(B1).subLocal(A1)
                 val u1 = Vec2.dot(e1, temp.set(B1).subLocal(Q))
 
                 // Is the circle in Region AB of the previous edge?
-                if (u1 > 0.0f) {
-                    return
-                }
+                if (u1 > 0.0f) return
             }
 
             cf.indexA = 0
@@ -663,7 +631,7 @@ class Collision(private val pool: IWorldPool) {
             manifold.localPoint.set(P)
             // manifold.points[0].id.key = 0;
             manifold.points[0].id.set(cf)
-            manifold.points[0].localPoint.set(circleB.m_p)
+            manifold.points[0].localPoint.set(circleB.p)
             return
         }
 
@@ -672,22 +640,18 @@ class Collision(private val pool: IWorldPool) {
             val P = B
             d.set(Q).subLocal(P)
             val dd = Vec2.dot(d, d)
-            if (dd > radius * radius) {
-                return
-            }
+            if (dd > radius * radius) return
 
             // Is there an edge connected to B?
-            if (edgeA.m_hasVertex3) {
-                val B2 = edgeA.m_vertex3
+            if (edgeA.hasVertex3) {
+                val B2 = edgeA.vertex3
                 val A2 = B
                 val e2 = e1
                 e2.set(B2).subLocal(A2)
                 val v2 = Vec2.dot(e2, temp.set(Q).subLocal(A2))
 
                 // Is the circle in Region AB of the next edge?
-                if (v2 > 0.0f) {
-                    return
-                }
+                if (v2 > 0.0f) return
             }
 
             cf.indexA = 1
@@ -698,7 +662,7 @@ class Collision(private val pool: IWorldPool) {
             manifold.localPoint.set(P)
             // manifold.points[0].id.key = 0;
             manifold.points[0].id.set(cf)
-            manifold.points[0].localPoint.set(circleB.m_p)
+            manifold.points[0].localPoint.set(circleB.p)
             return
         }
 
@@ -711,9 +675,7 @@ class Collision(private val pool: IWorldPool) {
         P.mulLocal(1.0f / den)
         d.set(Q).subLocal(P)
         val dd = Vec2.dot(d, d)
-        if (dd > radius * radius) {
-            return
-        }
+        if (dd > radius * radius) return
 
         n.x = -e.y
         n.y = e.x
@@ -725,22 +687,24 @@ class Collision(private val pool: IWorldPool) {
         cf.indexA = 0
         cf.typeA = ContactID.Type.FACE.ordinal.toByte()
         manifold.pointCount = 1
-        manifold.type = Manifold.ManifoldType.FACE_A
+        manifold.type = ManifoldType.FACE_A
         manifold.localNormal.set(n)
         manifold.localPoint.set(A)
         // manifold.points[0].id.key = 0;
         manifold.points[0].id.set(cf)
-        manifold.points[0].localPoint.set(circleB.m_p)
+        manifold.points[0].localPoint.set(circleB.p)
     }
 
-    fun collideEdgeAndPolygon(manifold: Manifold, edgeA: EdgeShape, xfA: Transform,
-                              polygonB: PolygonShape, xfB: Transform) {
+    fun collideEdgeAndPolygon(
+        manifold: Manifold, edgeA: EdgeShape, xfA: Transform,
+        polygonB: PolygonShape, xfB: Transform
+    ) {
         collider.collide(manifold, edgeA, xfA, polygonB, xfB)
     }
 
 
     /**
-     * Java-specific class for returning edge results
+     * A class for returning edge results
      */
     class EdgeResults {
         var separation: Float = 0.toFloat()
@@ -772,21 +736,16 @@ class Collision(private val pool: IWorldPool) {
      * @author Daniel Murphy
      */
     enum class PointState {
-        /**
-         * point does not exist
-         */
+        /** point does not exist */
         NULL_STATE,
-        /**
-         * point was added in the update
-         */
+
+        /** point was added in the update */
         ADD_STATE,
-        /**
-         * point persisted across the update
-         */
+
+        /** point persisted across the update */
         PERSIST_STATE,
-        /**
-         * point was removed in the update
-         */
+
+        /** point was removed in the update */
         REMOVE_STATE
     }
 
@@ -794,7 +753,6 @@ class Collision(private val pool: IWorldPool) {
      * This structure is used to keep track of the best separating axis.
      */
     internal class EPAxis {
-
         var type: Type? = null
         var index: Int = 0
         var separation: Float = 0.toFloat()
@@ -808,8 +766,8 @@ class Collision(private val pool: IWorldPool) {
      * This holds polygon B expressed in frame A.
      */
     internal class TempPolygon {
-        val vertices = Array<Vec2>(Settings.maxPolygonVertices) { Vec2() }
-        val normals = Array<Vec2>(Settings.maxPolygonVertices) { Vec2() }
+        val vertices = Array(Settings.maxPolygonVertices) { Vec2() }
+        val normals = Array(Settings.maxPolygonVertices) { Vec2() }
         var count: Int = 0
     }
 
@@ -835,34 +793,34 @@ class Collision(private val pool: IWorldPool) {
      */
     internal class EPCollider {
 
-        val m_polygonB = TempPolygon()
+        val polygonB = TempPolygon()
 
-        val m_xf = Transform()
-        val m_centroidB = Vec2()
-        var m_v0 = Vec2()
-        var m_v1 = Vec2()
-        var m_v2 = Vec2()
-        var m_v3 = Vec2()
-        val m_normal0 = Vec2()
-        val m_normal1 = Vec2()
-        val m_normal2 = Vec2()
-        val m_normal = Vec2()
+        val xf = Transform()
+        val centroidB = Vec2()
+        var v0 = Vec2()
+        var v1 = Vec2()
+        var v2 = Vec2()
+        var v3 = Vec2()
+        val normal0 = Vec2()
+        val normal1 = Vec2()
+        val normal2 = Vec2()
+        val normal = Vec2()
 
-        var m_type1: VertexType? = null
-        var m_type2: VertexType? = null
+        var type1: VertexType? = null
+        var type2: VertexType? = null
 
-        val m_lowerLimit = Vec2()
-        val m_upperLimit = Vec2()
-        var m_radius: Float = 0.toFloat()
-        var m_front: Boolean = false
+        val lowerLimit = Vec2()
+        val upperLimit = Vec2()
+        var radius: Float = 0.toFloat()
+        var front: Boolean = false
 
         private val edge1 = Vec2()
         private val temp = Vec2()
         private val edge0 = Vec2()
         private val edge2 = Vec2()
-        private val ie = Array<ClipVertex>(2) { ClipVertex() }
-        private val clipPoints1 = Array<ClipVertex>(2) { ClipVertex() }
-        private val clipPoints2 = Array<ClipVertex>(2) { ClipVertex() }
+        private val ie = Array(2) { ClipVertex() }
+        private val clipPoints1 = Array(2) { ClipVertex() }
+        private val clipPoints2 = Array(2) { ClipVertex() }
         private val rf = ReferenceFace()
         private val edgeAxis = EPAxis()
         private val polygonAxis = EPAxis()
@@ -876,24 +834,23 @@ class Collision(private val pool: IWorldPool) {
 
         private val poolVec2 = Vec2()
 
-        fun collide(manifold: Manifold, edgeA: EdgeShape, xfA: Transform,
-                    polygonB: PolygonShape, xfB: Transform) {
+        fun collide(
+            manifold: Manifold, edgeA: EdgeShape, xfA: Transform,
+            polygonB: PolygonShape, xfB: Transform
+        ) {
 
-            Transform.mulTransToOutUnsafe(xfA, xfB, m_xf, poolVec2)
-            Transform.mulToOutUnsafe(m_xf, polygonB.m_centroid, m_centroidB)
+            v0 = edgeA.vertex0
+            v1 = edgeA.vertex1
+            v2 = edgeA.vertex2
+            v3 = edgeA.vertex3
 
-            m_v0 = edgeA.m_vertex0
-            m_v1 = edgeA.m_vertex1
-            m_v2 = edgeA.m_vertex2
-            m_v3 = edgeA.m_vertex3
+            val hasVertex0 = edgeA.hasVertex0
+            val hasVertex3 = edgeA.hasVertex3
 
-            val hasVertex0 = edgeA.m_hasVertex0
-            val hasVertex3 = edgeA.m_hasVertex3
-
-            edge1.set(m_v2).subLocal(m_v1)
+            edge1.set(v2).subLocal(v1)
             edge1.normalize()
-            m_normal1.set(edge1.y, -edge1.x)
-            val offset1 = Vec2.dot(m_normal1, temp.set(m_centroidB).subLocal(m_v1))
+            normal1.set(edge1.y, -edge1.x)
+            val offset1 = Vec2.dot(normal1, temp.set(centroidB).subLocal(v1))
             var offset0 = 0.0f
             var offset2 = 0.0f
             var convex1 = false
@@ -901,192 +858,192 @@ class Collision(private val pool: IWorldPool) {
 
             // Is there a preceding edge?
             if (hasVertex0) {
-                edge0.set(m_v1).subLocal(m_v0)
+                edge0.set(v1).subLocal(v0)
                 edge0.normalize()
-                m_normal0.set(edge0.y, -edge0.x)
+                normal0.set(edge0.y, -edge0.x)
                 convex1 = Vec2.cross(edge0, edge1) >= 0.0f
-                offset0 = Vec2.dot(m_normal0, temp.set(m_centroidB).subLocal(m_v0))
+                offset0 = Vec2.dot(normal0, temp.set(centroidB).subLocal(v0))
             }
 
             // Is there a following edge?
             if (hasVertex3) {
-                edge2.set(m_v3).subLocal(m_v2)
+                edge2.set(v3).subLocal(v2)
                 edge2.normalize()
-                m_normal2.set(edge2.y, -edge2.x)
+                normal2.set(edge2.y, -edge2.x)
                 convex2 = Vec2.cross(edge1, edge2) > 0.0f
-                offset2 = Vec2.dot(m_normal2, temp.set(m_centroidB).subLocal(m_v2))
+                offset2 = Vec2.dot(normal2, temp.set(centroidB).subLocal(v2))
             }
 
             // Determine front or back collision. Determine collision normal limits.
             if (hasVertex0 && hasVertex3) {
                 if (convex1 && convex2) {
-                    m_front = offset0 >= 0.0f || offset1 >= 0.0f || offset2 >= 0.0f
-                    if (m_front) {
-                        m_normal.x = m_normal1.x
-                        m_normal.y = m_normal1.y
-                        m_lowerLimit.x = m_normal0.x
-                        m_lowerLimit.y = m_normal0.y
-                        m_upperLimit.x = m_normal2.x
-                        m_upperLimit.y = m_normal2.y
+                    front = offset0 >= 0.0f || offset1 >= 0.0f || offset2 >= 0.0f
+                    if (front) {
+                        normal.x = normal1.x
+                        normal.y = normal1.y
+                        lowerLimit.x = normal0.x
+                        lowerLimit.y = normal0.y
+                        upperLimit.x = normal2.x
+                        upperLimit.y = normal2.y
                     } else {
-                        m_normal.x = -m_normal1.x
-                        m_normal.y = -m_normal1.y
-                        m_lowerLimit.x = -m_normal1.x
-                        m_lowerLimit.y = -m_normal1.y
-                        m_upperLimit.x = -m_normal1.x
-                        m_upperLimit.y = -m_normal1.y
+                        normal.x = -normal1.x
+                        normal.y = -normal1.y
+                        lowerLimit.x = -normal1.x
+                        lowerLimit.y = -normal1.y
+                        upperLimit.x = -normal1.x
+                        upperLimit.y = -normal1.y
                     }
                 } else if (convex1) {
-                    m_front = offset0 >= 0.0f || offset1 >= 0.0f && offset2 >= 0.0f
-                    if (m_front) {
-                        m_normal.x = m_normal1.x
-                        m_normal.y = m_normal1.y
-                        m_lowerLimit.x = m_normal0.x
-                        m_lowerLimit.y = m_normal0.y
-                        m_upperLimit.x = m_normal1.x
-                        m_upperLimit.y = m_normal1.y
+                    front = offset0 >= 0.0f || offset1 >= 0.0f && offset2 >= 0.0f
+                    if (front) {
+                        normal.x = normal1.x
+                        normal.y = normal1.y
+                        lowerLimit.x = normal0.x
+                        lowerLimit.y = normal0.y
+                        upperLimit.x = normal1.x
+                        upperLimit.y = normal1.y
                     } else {
-                        m_normal.x = -m_normal1.x
-                        m_normal.y = -m_normal1.y
-                        m_lowerLimit.x = -m_normal2.x
-                        m_lowerLimit.y = -m_normal2.y
-                        m_upperLimit.x = -m_normal1.x
-                        m_upperLimit.y = -m_normal1.y
+                        normal.x = -normal1.x
+                        normal.y = -normal1.y
+                        lowerLimit.x = -normal2.x
+                        lowerLimit.y = -normal2.y
+                        upperLimit.x = -normal1.x
+                        upperLimit.y = -normal1.y
                     }
                 } else if (convex2) {
-                    m_front = offset2 >= 0.0f || offset0 >= 0.0f && offset1 >= 0.0f
-                    if (m_front) {
-                        m_normal.x = m_normal1.x
-                        m_normal.y = m_normal1.y
-                        m_lowerLimit.x = m_normal1.x
-                        m_lowerLimit.y = m_normal1.y
-                        m_upperLimit.x = m_normal2.x
-                        m_upperLimit.y = m_normal2.y
+                    front = offset2 >= 0.0f || offset0 >= 0.0f && offset1 >= 0.0f
+                    if (front) {
+                        normal.x = normal1.x
+                        normal.y = normal1.y
+                        lowerLimit.x = normal1.x
+                        lowerLimit.y = normal1.y
+                        upperLimit.x = normal2.x
+                        upperLimit.y = normal2.y
                     } else {
-                        m_normal.x = -m_normal1.x
-                        m_normal.y = -m_normal1.y
-                        m_lowerLimit.x = -m_normal1.x
-                        m_lowerLimit.y = -m_normal1.y
-                        m_upperLimit.x = -m_normal0.x
-                        m_upperLimit.y = -m_normal0.y
+                        normal.x = -normal1.x
+                        normal.y = -normal1.y
+                        lowerLimit.x = -normal1.x
+                        lowerLimit.y = -normal1.y
+                        upperLimit.x = -normal0.x
+                        upperLimit.y = -normal0.y
                     }
                 } else {
-                    m_front = offset0 >= 0.0f && offset1 >= 0.0f && offset2 >= 0.0f
-                    if (m_front) {
-                        m_normal.x = m_normal1.x
-                        m_normal.y = m_normal1.y
-                        m_lowerLimit.x = m_normal1.x
-                        m_lowerLimit.y = m_normal1.y
-                        m_upperLimit.x = m_normal1.x
-                        m_upperLimit.y = m_normal1.y
+                    front = offset0 >= 0.0f && offset1 >= 0.0f && offset2 >= 0.0f
+                    if (front) {
+                        normal.x = normal1.x
+                        normal.y = normal1.y
+                        lowerLimit.x = normal1.x
+                        lowerLimit.y = normal1.y
+                        upperLimit.x = normal1.x
+                        upperLimit.y = normal1.y
                     } else {
-                        m_normal.x = -m_normal1.x
-                        m_normal.y = -m_normal1.y
-                        m_lowerLimit.x = -m_normal2.x
-                        m_lowerLimit.y = -m_normal2.y
-                        m_upperLimit.x = -m_normal0.x
-                        m_upperLimit.y = -m_normal0.y
+                        normal.x = -normal1.x
+                        normal.y = -normal1.y
+                        lowerLimit.x = -normal2.x
+                        lowerLimit.y = -normal2.y
+                        upperLimit.x = -normal0.x
+                        upperLimit.y = -normal0.y
                     }
                 }
             } else if (hasVertex0) {
                 if (convex1) {
-                    m_front = offset0 >= 0.0f || offset1 >= 0.0f
-                    if (m_front) {
-                        m_normal.x = m_normal1.x
-                        m_normal.y = m_normal1.y
-                        m_lowerLimit.x = m_normal0.x
-                        m_lowerLimit.y = m_normal0.y
-                        m_upperLimit.x = -m_normal1.x
-                        m_upperLimit.y = -m_normal1.y
+                    front = offset0 >= 0.0f || offset1 >= 0.0f
+                    if (front) {
+                        normal.x = normal1.x
+                        normal.y = normal1.y
+                        lowerLimit.x = normal0.x
+                        lowerLimit.y = normal0.y
+                        upperLimit.x = -normal1.x
+                        upperLimit.y = -normal1.y
                     } else {
-                        m_normal.x = -m_normal1.x
-                        m_normal.y = -m_normal1.y
-                        m_lowerLimit.x = m_normal1.x
-                        m_lowerLimit.y = m_normal1.y
-                        m_upperLimit.x = -m_normal1.x
-                        m_upperLimit.y = -m_normal1.y
+                        normal.x = -normal1.x
+                        normal.y = -normal1.y
+                        lowerLimit.x = normal1.x
+                        lowerLimit.y = normal1.y
+                        upperLimit.x = -normal1.x
+                        upperLimit.y = -normal1.y
                     }
                 } else {
-                    m_front = offset0 >= 0.0f && offset1 >= 0.0f
-                    if (m_front) {
-                        m_normal.x = m_normal1.x
-                        m_normal.y = m_normal1.y
-                        m_lowerLimit.x = m_normal1.x
-                        m_lowerLimit.y = m_normal1.y
-                        m_upperLimit.x = -m_normal1.x
-                        m_upperLimit.y = -m_normal1.y
+                    front = offset0 >= 0.0f && offset1 >= 0.0f
+                    if (front) {
+                        normal.x = normal1.x
+                        normal.y = normal1.y
+                        lowerLimit.x = normal1.x
+                        lowerLimit.y = normal1.y
+                        upperLimit.x = -normal1.x
+                        upperLimit.y = -normal1.y
                     } else {
-                        m_normal.x = -m_normal1.x
-                        m_normal.y = -m_normal1.y
-                        m_lowerLimit.x = m_normal1.x
-                        m_lowerLimit.y = m_normal1.y
-                        m_upperLimit.x = -m_normal0.x
-                        m_upperLimit.y = -m_normal0.y
+                        normal.x = -normal1.x
+                        normal.y = -normal1.y
+                        lowerLimit.x = normal1.x
+                        lowerLimit.y = normal1.y
+                        upperLimit.x = -normal0.x
+                        upperLimit.y = -normal0.y
                     }
                 }
             } else if (hasVertex3) {
                 if (convex2) {
-                    m_front = offset1 >= 0.0f || offset2 >= 0.0f
-                    if (m_front) {
-                        m_normal.x = m_normal1.x
-                        m_normal.y = m_normal1.y
-                        m_lowerLimit.x = -m_normal1.x
-                        m_lowerLimit.y = -m_normal1.y
-                        m_upperLimit.x = m_normal2.x
-                        m_upperLimit.y = m_normal2.y
+                    front = offset1 >= 0.0f || offset2 >= 0.0f
+                    if (front) {
+                        normal.x = normal1.x
+                        normal.y = normal1.y
+                        lowerLimit.x = -normal1.x
+                        lowerLimit.y = -normal1.y
+                        upperLimit.x = normal2.x
+                        upperLimit.y = normal2.y
                     } else {
-                        m_normal.x = -m_normal1.x
-                        m_normal.y = -m_normal1.y
-                        m_lowerLimit.x = -m_normal1.x
-                        m_lowerLimit.y = -m_normal1.y
-                        m_upperLimit.x = m_normal1.x
-                        m_upperLimit.y = m_normal1.y
+                        normal.x = -normal1.x
+                        normal.y = -normal1.y
+                        lowerLimit.x = -normal1.x
+                        lowerLimit.y = -normal1.y
+                        upperLimit.x = normal1.x
+                        upperLimit.y = normal1.y
                     }
                 } else {
-                    m_front = offset1 >= 0.0f && offset2 >= 0.0f
-                    if (m_front) {
-                        m_normal.x = m_normal1.x
-                        m_normal.y = m_normal1.y
-                        m_lowerLimit.x = -m_normal1.x
-                        m_lowerLimit.y = -m_normal1.y
-                        m_upperLimit.x = m_normal1.x
-                        m_upperLimit.y = m_normal1.y
+                    front = offset1 >= 0.0f && offset2 >= 0.0f
+                    if (front) {
+                        normal.x = normal1.x
+                        normal.y = normal1.y
+                        lowerLimit.x = -normal1.x
+                        lowerLimit.y = -normal1.y
+                        upperLimit.x = normal1.x
+                        upperLimit.y = normal1.y
                     } else {
-                        m_normal.x = -m_normal1.x
-                        m_normal.y = -m_normal1.y
-                        m_lowerLimit.x = -m_normal2.x
-                        m_lowerLimit.y = -m_normal2.y
-                        m_upperLimit.x = m_normal1.x
-                        m_upperLimit.y = m_normal1.y
+                        normal.x = -normal1.x
+                        normal.y = -normal1.y
+                        lowerLimit.x = -normal2.x
+                        lowerLimit.y = -normal2.y
+                        upperLimit.x = normal1.x
+                        upperLimit.y = normal1.y
                     }
                 }
             } else {
-                m_front = offset1 >= 0.0f
-                if (m_front) {
-                    m_normal.x = m_normal1.x
-                    m_normal.y = m_normal1.y
-                    m_lowerLimit.x = -m_normal1.x
-                    m_lowerLimit.y = -m_normal1.y
-                    m_upperLimit.x = -m_normal1.x
-                    m_upperLimit.y = -m_normal1.y
+                front = offset1 >= 0.0f
+                if (front) {
+                    normal.x = normal1.x
+                    normal.y = normal1.y
+                    lowerLimit.x = -normal1.x
+                    lowerLimit.y = -normal1.y
+                    upperLimit.x = -normal1.x
+                    upperLimit.y = -normal1.y
                 } else {
-                    m_normal.x = -m_normal1.x
-                    m_normal.y = -m_normal1.y
-                    m_lowerLimit.x = m_normal1.x
-                    m_lowerLimit.y = m_normal1.y
-                    m_upperLimit.x = m_normal1.x
-                    m_upperLimit.y = m_normal1.y
+                    normal.x = -normal1.x
+                    normal.y = -normal1.y
+                    lowerLimit.x = normal1.x
+                    lowerLimit.y = normal1.y
+                    upperLimit.x = normal1.x
+                    upperLimit.y = normal1.y
                 }
             }
 
             // Get polygonB in frameA
-            m_polygonB.count = polygonB.m_count
-            for (i in 0 until polygonB.m_count) {
-                Transform.mulToOutUnsafe(m_xf, polygonB.m_vertices[i], m_polygonB.vertices[i])
-                Rot.mulToOutUnsafe(m_xf.q, polygonB.m_normals[i], m_polygonB.normals[i])
+            this.polygonB.count = polygonB.vertexCount
+            for (i in 0 until polygonB.vertexCount) {
+                Transform.mulToOutUnsafe(xf, polygonB.vertices[i], this.polygonB.vertices[i])
+                Rot.mulToOutUnsafe(xf.q, polygonB.normals[i], this.polygonB.normals[i])
             }
 
-            m_radius = 2.0f * Settings.polygonRadius
+            radius = 2.0f * Settings.polygonRadius
 
             manifold.pointCount = 0
 
@@ -1097,12 +1054,12 @@ class Collision(private val pool: IWorldPool) {
                 return
             }
 
-            if (edgeAxis.separation > m_radius) {
+            if (edgeAxis.separation > radius) {
                 return
             }
 
             computePolygonSeparation(polygonAxis)
-            if (polygonAxis.type != EPAxis.Type.UNKNOWN && polygonAxis.separation > m_radius) {
+            if (polygonAxis.type != EPAxis.Type.UNKNOWN && polygonAxis.separation > radius) {
                 return
             }
 
@@ -1123,13 +1080,13 @@ class Collision(private val pool: IWorldPool) {
             val ie1 = ie[1]
 
             if (primaryAxis.type == EPAxis.Type.EDGE_A) {
-                manifold.type = Manifold.ManifoldType.FACE_A
+                manifold.type = ManifoldType.FACE_A
 
                 // Search for the polygon normal that is most anti-parallel to the edge normal.
                 var bestIndex = 0
-                var bestValue = Vec2.dot(m_normal, m_polygonB.normals[0])
-                for (i in 1 until m_polygonB.count) {
-                    val value = Vec2.dot(m_normal, m_polygonB.normals[i])
+                var bestValue = Vec2.dot(normal, this.polygonB.normals[0])
+                for (i in 1 until this.polygonB.count) {
+                    val value = Vec2.dot(normal, this.polygonB.normals[i])
                     if (value < bestValue) {
                         bestValue = value
                         bestIndex = i
@@ -1137,53 +1094,53 @@ class Collision(private val pool: IWorldPool) {
                 }
 
                 val i1 = bestIndex
-                val i2 = if (i1 + 1 < m_polygonB.count) i1 + 1 else 0
+                val i2 = if (i1 + 1 < this.polygonB.count) i1 + 1 else 0
 
-                ie0.v.set(m_polygonB.vertices[i1])
+                ie0.v.set(this.polygonB.vertices[i1])
                 ie0.id.indexA = 0
                 ie0.id.indexB = i1.toByte()
                 ie0.id.typeA = ContactID.Type.FACE.ordinal.toByte()
                 ie0.id.typeB = ContactID.Type.VERTEX.ordinal.toByte()
 
-                ie1.v.set(m_polygonB.vertices[i2])
+                ie1.v.set(this.polygonB.vertices[i2])
                 ie1.id.indexA = 0
                 ie1.id.indexB = i2.toByte()
                 ie1.id.typeA = ContactID.Type.FACE.ordinal.toByte()
                 ie1.id.typeB = ContactID.Type.VERTEX.ordinal.toByte()
 
-                if (m_front) {
+                if (front) {
                     rf.i1 = 0
                     rf.i2 = 1
-                    rf.v1.set(m_v1)
-                    rf.v2.set(m_v2)
-                    rf.normal.set(m_normal1)
+                    rf.v1.set(v1)
+                    rf.v2.set(v2)
+                    rf.normal.set(normal1)
                 } else {
                     rf.i1 = 1
                     rf.i2 = 0
-                    rf.v1.set(m_v2)
-                    rf.v2.set(m_v1)
-                    rf.normal.set(m_normal1).negateLocal()
+                    rf.v1.set(v2)
+                    rf.v2.set(v1)
+                    rf.normal.set(normal1).negateLocal()
                 }
             } else {
-                manifold.type = Manifold.ManifoldType.FACE_B
+                manifold.type = ManifoldType.FACE_B
 
-                ie0.v.set(m_v1)
+                ie0.v.set(v1)
                 ie0.id.indexA = 0
                 ie0.id.indexB = primaryAxis.index.toByte()
                 ie0.id.typeA = ContactID.Type.VERTEX.ordinal.toByte()
                 ie0.id.typeB = ContactID.Type.FACE.ordinal.toByte()
 
-                ie1.v.set(m_v2)
+                ie1.v.set(v2)
                 ie1.id.indexA = 0
                 ie1.id.indexB = primaryAxis.index.toByte()
                 ie1.id.typeA = ContactID.Type.VERTEX.ordinal.toByte()
                 ie1.id.typeB = ContactID.Type.FACE.ordinal.toByte()
 
                 rf.i1 = primaryAxis.index
-                rf.i2 = if (rf.i1 + 1 < m_polygonB.count) rf.i1 + 1 else 0
-                rf.v1.set(m_polygonB.vertices[rf.i1])
-                rf.v2.set(m_polygonB.vertices[rf.i2])
-                rf.normal.set(m_polygonB.normals[rf.i1])
+                rf.i2 = if (rf.i1 + 1 < this.polygonB.count) rf.i1 + 1 else 0
+                rf.v1.set(this.polygonB.vertices[rf.i1])
+                rf.v2.set(this.polygonB.vertices[rf.i2])
+                rf.normal.set(this.polygonB.normals[rf.i1])
             }
 
             rf.sideNormal1.set(rf.normal.y, -rf.normal.x)
@@ -1191,11 +1148,8 @@ class Collision(private val pool: IWorldPool) {
             rf.sideOffset1 = Vec2.dot(rf.sideNormal1, rf.v1)
             rf.sideOffset2 = Vec2.dot(rf.sideNormal2, rf.v2)
 
-            // Clip incident edge against extruded edge1 side edges.
-            var np: Int
-
-            // Clip to box side 1
-            np = clipSegmentToLine(clipPoints1, ie, rf.sideNormal1, rf.sideOffset1, rf.i1)
+            // Clip incident edge against extruded edge1 side edges. Clip to box side 1
+            var np = clipSegmentToLine(clipPoints1, ie, rf.sideNormal1, rf.sideOffset1, rf.i1)
 
             if (np < Settings.maxManifoldPoints) {
                 return
@@ -1213,22 +1167,21 @@ class Collision(private val pool: IWorldPool) {
                 manifold.localNormal.set(rf.normal)
                 manifold.localPoint.set(rf.v1)
             } else {
-                manifold.localNormal.set(polygonB.m_normals[rf.i1])
-                manifold.localPoint.set(polygonB.m_vertices[rf.i1])
+                manifold.localNormal.set(polygonB.normals[rf.i1])
+                manifold.localPoint.set(polygonB.vertices[rf.i1])
             }
 
             var pointCount = 0
             for (i in 0 until Settings.maxManifoldPoints) {
-                val separation: Float
 
-                separation = Vec2.dot(rf.normal, temp.set(clipPoints2[i].v).subLocal(rf.v1))
+                val separation = Vec2.dot(rf.normal, temp.set(clipPoints2[i].v).subLocal(rf.v1))
 
-                if (separation <= m_radius) {
+                if (separation <= radius) {
                     val cp = manifold.points[pointCount]
 
                     if (primaryAxis.type == EPAxis.Type.EDGE_A) {
                         // cp.localPoint = MulT(m_xf, clipPoints2[i].v);
-                        Transform.mulTransToOutUnsafe(m_xf, clipPoints2[i].v, cp.localPoint)
+                        Transform.mulTransToOutUnsafe(xf, clipPoints2[i].v, cp.localPoint)
                         cp.id.set(clipPoints2[i].id)
                     } else {
                         cp.localPoint.set(clipPoints2[i].v)
@@ -1245,18 +1198,17 @@ class Collision(private val pool: IWorldPool) {
             manifold.pointCount = pointCount
         }
 
-
         fun computeEdgeSeparation(axis: EPAxis) {
             axis.type = EPAxis.Type.EDGE_A
-            axis.index = if (m_front) 0 else 1
+            axis.index = if (front) 0 else 1
             axis.separation = Float.MAX_VALUE
-            val nx = m_normal.x
-            val ny = m_normal.y
+            val nx = normal.x
+            val ny = normal.y
 
-            for (i in 0 until m_polygonB.count) {
-                val v = m_polygonB.vertices[i]
-                val tempx = v.x - m_v1.x
-                val tempy = v.y - m_v1.y
+            for (i in 0 until polygonB.count) {
+                val v = polygonB.vertices[i]
+                val tempx = v.x - v1.x
+                val tempy = v.y - v1.y
                 val s = nx * tempx + ny * tempy
                 if (s < axis.separation) {
                     axis.separation = s
@@ -1269,26 +1221,26 @@ class Collision(private val pool: IWorldPool) {
             axis.index = -1
             axis.separation = -Float.MAX_VALUE
 
-            perp.x = -m_normal.y
-            perp.y = m_normal.x
+            perp.x = -normal.y
+            perp.y = normal.x
 
-            for (i in 0 until m_polygonB.count) {
-                val normalB = m_polygonB.normals[i]
-                val vB = m_polygonB.vertices[i]
+            for (i in 0 until polygonB.count) {
+                val normalB = polygonB.normals[i]
+                val vB = polygonB.vertices[i]
                 n.x = -normalB.x
                 n.y = -normalB.y
 
                 // float s1 = Vec2.dot(n, temp.set(vB).subLocal(m_v1));
                 // float s2 = Vec2.dot(n, temp.set(vB).subLocal(m_v2));
-                var tempx = vB.x - m_v1.x
-                var tempy = vB.y - m_v1.y
+                var tempx = vB.x - v1.x
+                var tempy = vB.y - v1.y
                 val s1 = n.x * tempx + n.y * tempy
-                tempx = vB.x - m_v2.x
-                tempy = vB.y - m_v2.y
+                tempx = vB.x - v2.x
+                tempy = vB.y - v2.y
                 val s2 = n.x * tempx + n.y * tempy
                 val s = MathUtils.min(s1, s2)
 
-                if (s > m_radius) {
+                if (s > radius) {
                     // No collision
                     axis.type = EPAxis.Type.EDGE_B
                     axis.index = i
@@ -1298,11 +1250,11 @@ class Collision(private val pool: IWorldPool) {
 
                 // Adjacency
                 if (n.x * perp.x + n.y * perp.y >= 0.0f) {
-                    if (Vec2.dot(temp.set(n).subLocal(m_upperLimit), m_normal) < -Settings.angularSlop) {
+                    if (Vec2.dot(temp.set(n).subLocal(upperLimit), normal) < -Settings.angularSlop) {
                         continue
                     }
                 } else {
-                    if (Vec2.dot(temp.set(n).subLocal(m_lowerLimit), m_normal) < -Settings.angularSlop) {
+                    if (Vec2.dot(temp.set(n).subLocal(lowerLimit), normal) < -Settings.angularSlop) {
                         continue
                     }
                 }
@@ -1318,9 +1270,6 @@ class Collision(private val pool: IWorldPool) {
 
     // #### COLLISION STUFF (not from collision.h or collision.cpp) ####
 
-    // djm pooling
-    private val d = Vec2()
-
     companion object {
 
         val NULL_FEATURE = Int.MAX_VALUE
@@ -1329,15 +1278,11 @@ class Collision(private val pool: IWorldPool) {
          * Compute the point states given two manifolds. The states pertain to the transition from
          * manifold1 to manifold2. So state1 is either persist or remove while state2 is either add or
          * persist.
-         *
-         * @param state1
-         * @param state2
-         * @param manifold1
-         * @param manifold2
          */
-
-        fun getPointStates(state1: Array<PointState>, state2: Array<PointState>,
-                           manifold1: Manifold, manifold2: Manifold) {
+        fun getPointStates(
+            state1: Array<PointState>, state2: Array<PointState>,
+            manifold1: Manifold, manifold2: Manifold
+        ) {
 
             for (i in 0 until Settings.maxManifoldPoints) {
                 state1[i] = PointState.NULL_STATE
@@ -1375,16 +1320,11 @@ class Collision(private val pool: IWorldPool) {
 
         /**
          * Clipping for contact manifolds. Sutherland-Hodgman clipping.
-         *
-         * @param vOut
-         * @param vIn
-         * @param normal
-         * @param offset
-         * @return
          */
-
-        fun clipSegmentToLine(vOut: Array<ClipVertex>, vIn: Array<ClipVertex>,
-                              normal: Vec2, offset: Float, vertexIndexA: Int): Int {
+        fun clipSegmentToLine(
+            vOut: Array<ClipVertex>, vIn: Array<ClipVertex>,
+            normal: Vec2, offset: Float, vertexIndexA: Int
+        ): Int {
 
             // Start with no output points
             var numOut = 0

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/ContactID.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/ContactID.kt
@@ -50,17 +50,14 @@ package org.jbox2d.collision
  */
 class ContactID : Comparable<ContactID> {
 
-
     var indexA: Byte = 0
-
     var indexB: Byte = 0
 
     var typeA: Byte = 0
-
     var typeB: Byte = 0
 
     val key: Int
-        get() = indexA.toInt() shl 24 or (indexB.toInt() shl 16) or (typeA.toInt() shl 8) or typeB.toInt()
+        get() = (indexA.toInt() shl 24) or (indexB.toInt() shl 16) or (typeA.toInt() shl 8) or typeB.toInt()
 
     enum class Type {
         VERTEX, FACE
@@ -70,7 +67,7 @@ class ContactID : Comparable<ContactID> {
         return key == cid.key
     }
 
-    constructor() {}
+    constructor()
 
     constructor(c: ContactID) {
         set(c)
@@ -92,9 +89,7 @@ class ContactID : Comparable<ContactID> {
         typeB = tempA
     }
 
-    /**
-     * zeros out the data
-     */
+    /** zeros out the data */
     fun zero() {
         indexA = 0
         indexB = 0
@@ -102,7 +97,7 @@ class ContactID : Comparable<ContactID> {
         typeB = 0
     }
 
-    override fun compareTo(o: ContactID): Int {
-        return key - o.key
+    override fun compareTo(other: ContactID): Int {
+        return key - other.key
     }
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/Distance.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/Distance.kt
@@ -31,7 +31,6 @@ import org.jbox2d.common.Vec2
 import org.jbox2d.common.Transform
 import org.jbox2d.internal.*
 
-// updated to rev 100
 /**
  * This is non-static for faster pooling. To get an instance, use the [SingletonPool], don't
  * construct a distance object.
@@ -76,15 +75,13 @@ class Distance(val stats: Stats = Stats()) {
      */
     class SimplexCache {
         /** length or area  */
-
         var metric: Float = 0.toFloat()
-
         var count: Int = 0
+
         /** vertices on shape A  */
-
         val indexA = IntArray(3)
-        /** vertices on shape B  */
 
+        /** vertices on shape B  */
         val indexB = IntArray(3)
 
         init {
@@ -107,11 +104,11 @@ class Distance(val stats: Stats = Stats()) {
     }
 
     private inner class Simplex {
-        val m_v1 = SimplexVertex()
-        val m_v2 = SimplexVertex()
-        val m_v3 = SimplexVertex()
-        val vertices = arrayOf(m_v1, m_v2, m_v3)
-        var m_count: Int = 0
+        val v1 = SimplexVertex()
+        val v2 = SimplexVertex()
+        val v3 = SimplexVertex()
+        val vertices = arrayOf(v1, v2, v3)
+        var count: Int = 0
 
         private val e12 = Vec2()
 
@@ -126,27 +123,21 @@ class Distance(val stats: Stats = Stats()) {
         // djm pooled, from above
         // return Vec2.cross(m_v2.w - m_v1.w, m_v3.w - m_v1.w);
         val metric: Float
-            get() {
-                when (m_count) {
-                    0 -> {
-                        assert(false)
-                        return 0.0f
-                    }
-
-                    1 -> return 0.0f
-
-                    2 -> return MathUtils.distance(m_v1.w, m_v2.w)
-
-                    3 -> {
-                        case3.set(m_v2.w).subLocal(m_v1.w)
-                        case33.set(m_v3.w).subLocal(m_v1.w)
-                        return Vec2.cross(case3, case33)
-                    }
-
-                    else -> {
-                        assert(false)
-                        return 0.0f
-                    }
+            get() = when (count) {
+                0 -> {
+                    assert(false)
+                    0.0f
+                }
+                1 -> 0.0f
+                2 -> MathUtils.distance(v1.w, v2.w)
+                3 -> {
+                    case3.set(v2.w).subLocal(v1.w)
+                    case33.set(v3.w).subLocal(v1.w)
+                    Vec2.cross(case3, case33)
+                }
+                else -> {
+                    assert(false)
+                    0.0f
                 }
             }
 
@@ -157,14 +148,16 @@ class Distance(val stats: Stats = Stats()) {
         private val w2 = Vec2()
         private val w3 = Vec2()
 
-        fun readCache(cache: SimplexCache, proxyA: DistanceProxy, transformA: Transform,
-                      proxyB: DistanceProxy, transformB: Transform) {
+        fun readCache(
+            cache: SimplexCache, proxyA: DistanceProxy, transformA: Transform,
+            proxyB: DistanceProxy, transformB: Transform
+        ) {
             assert(cache.count <= 3)
 
             // Copy data from cache.
-            m_count = cache.count
+            count = cache.count
 
-            for (i in 0 until m_count) {
+            for (i in 0 until count) {
                 val v = vertices[i]
                 v.indexA = cache.indexA[i]
                 v.indexB = cache.indexB[i]
@@ -178,17 +171,17 @@ class Distance(val stats: Stats = Stats()) {
 
             // Compute the new simplex metric, if it is substantially different than
             // old metric then flush the simplex.
-            if (m_count > 1) {
+            if (count > 1) {
                 val metric1 = cache.metric
                 val metric2 = metric
                 if (metric2 < 0.5f * metric1 || 2.0f * metric1 < metric2 || metric2 < Settings.EPSILON) {
                     // Reset the simplex.
-                    m_count = 0
+                    count = 0
                 }
             }
 
             // If the cache is empty or invalid ...
-            if (m_count == 0) {
+            if (count == 0) {
                 val v = vertices[0]
                 v.indexA = 0
                 v.indexB = 0
@@ -197,41 +190,40 @@ class Distance(val stats: Stats = Stats()) {
                 Transform.mulToOutUnsafe(transformA, wALocal, v.wA)
                 Transform.mulToOutUnsafe(transformB, wBLocal, v.wB)
                 v.w.set(v.wB).subLocal(v.wA)
-                m_count = 1
+                count = 1
             }
         }
 
         fun writeCache(cache: SimplexCache) {
             cache.metric = metric
-            cache.count = m_count
+            cache.count = count
 
-            for (i in 0 until m_count) {
+            for (i in 0 until count) {
                 cache.indexA[i] = vertices[i].indexA
                 cache.indexB[i] = vertices[i].indexB
             }
         }
 
         fun getSearchDirection(out: Vec2) {
-            when (m_count) {
+            when (count) {
                 1 -> {
-                    out.set(m_v1.w).negateLocal()
+                    out.set(v1.w).negateLocal()
                     return
                 }
                 2 -> {
-                    e12.set(m_v2.w).subLocal(m_v1.w)
+                    e12.set(v2.w).subLocal(v1.w)
                     // use out for a temp variable real quick
-                    out.set(m_v1.w).negateLocal()
+                    out.set(v1.w).negateLocal()
                     val sgn = Vec2.cross(e12, out)
 
                     if (sgn > 0f) {
                         // Origin is left of e12.
                         Vec2.crossToOutUnsafe(1f, e12, out)
-                        return
                     } else {
                         // Origin is right of e12.
                         Vec2.crossToOutUnsafe(e12, 1f, out)
-                        return
                     }
+                    return
                 }
                 else -> {
                     assert(false)
@@ -242,24 +234,22 @@ class Distance(val stats: Stats = Stats()) {
         }
 
         /**
-         * this returns pooled objects. don't keep or modify them
-         *
-         * @return
+         * Returns pooled objects. Don't keep or modify them
          */
         fun getClosestPoint(out: Vec2) {
-            when (m_count) {
+            when (count) {
                 0 -> {
                     assert(false)
                     out.setZero()
                     return
                 }
                 1 -> {
-                    out.set(m_v1.w)
+                    out.set(v1.w)
                     return
                 }
                 2 -> {
-                    case22.set(m_v2.w).mulLocal(m_v2.a)
-                    case2.set(m_v1.w).mulLocal(m_v1.a).addLocal(case22)
+                    case22.set(v2.w).mulLocal(v2.a)
+                    case2.set(v1.w).mulLocal(v1.a).addLocal(case22)
                     out.set(case2)
                     return
                 }
@@ -276,33 +266,30 @@ class Distance(val stats: Stats = Stats()) {
         }
 
         fun getWitnessPoints(pA: Vec2, pB: Vec2) {
-            when (m_count) {
+            when (count) {
                 0 -> assert(false)
-
                 1 -> {
-                    pA.set(m_v1.wA)
-                    pB.set(m_v1.wB)
+                    pA.set(v1.wA)
+                    pB.set(v1.wB)
                 }
-
                 2 -> {
-                    case2.set(m_v1.wA).mulLocal(m_v1.a)
-                    pA.set(m_v2.wA).mulLocal(m_v2.a).addLocal(case2)
+                    case2.set(v1.wA).mulLocal(v1.a)
+                    pA.set(v2.wA).mulLocal(v2.a).addLocal(case2)
                     // m_v1.a * m_v1.wA + m_v2.a * m_v2.wA;
                     // *pB = m_v1.a * m_v1.wB + m_v2.a * m_v2.wB;
-                    case2.set(m_v1.wB).mulLocal(m_v1.a)
-                    pB.set(m_v2.wB).mulLocal(m_v2.a).addLocal(case2)
+                    case2.set(v1.wB).mulLocal(v1.a)
+                    pB.set(v2.wB).mulLocal(v2.a).addLocal(case2)
                 }
-
                 3 -> {
-                    pA.set(m_v1.wA).mulLocal(m_v1.a)
-                    case3.set(m_v2.wA).mulLocal(m_v2.a)
-                    case33.set(m_v3.wA).mulLocal(m_v3.a)
+                    pA.set(v1.wA).mulLocal(v1.a)
+                    case3.set(v2.wA).mulLocal(v2.a)
+                    case33.set(v3.wA).mulLocal(v3.a)
                     pA.addLocal(case3).addLocal(case33)
                     pB.set(pA)
                 }
-
                 else -> assert(false)
-            }// *pA = m_v1.a * m_v1.wA + m_v2.a * m_v2.wA + m_v3.a * m_v3.wA;
+            }
+            // *pA = m_v1.a * m_v1.wA + m_v2.a * m_v2.wA + m_v3.a * m_v3.wA;
             // *pB = *pA;
         }
 
@@ -334,16 +321,16 @@ class Distance(val stats: Stats = Stats()) {
             // Solution
             // a1 = d12_1 / d12
             // a2 = d12_2 / d12
-            val w1 = m_v1.w
-            val w2 = m_v2.w
+            val w1 = v1.w
+            val w2 = v2.w
             e12.set(w2).subLocal(w1)
 
             // w1 region
             val d12_2 = -Vec2.dot(w1, e12)
             if (d12_2 <= 0.0f) {
                 // a2 <= 0, so we clamp it to 0
-                m_v1.a = 1.0f
-                m_count = 1
+                v1.a = 1.0f
+                count = 1
                 return
             }
 
@@ -351,31 +338,31 @@ class Distance(val stats: Stats = Stats()) {
             val d12_1 = Vec2.dot(w2, e12)
             if (d12_1 <= 0.0f) {
                 // a1 <= 0, so we clamp it to 0
-                m_v2.a = 1.0f
-                m_count = 1
-                m_v1.set(m_v2)
+                v2.a = 1.0f
+                count = 1
+                v1.set(v2)
                 return
             }
 
             // Must be in e12 region.
             val inv_d12 = 1.0f / (d12_1 + d12_2)
-            m_v1.a = d12_1 * inv_d12
-            m_v2.a = d12_2 * inv_d12
-            m_count = 2
+            v1.a = d12_1 * inv_d12
+            v2.a = d12_2 * inv_d12
+            count = 2
         }
 
         /**
-         * Solve a line segment using barycentric coordinates.<br></br>
-         * Possible regions:<br></br>
-         * - points[2]<br></br>
-         * - edge points[0]-points[2]<br></br>
-         * - edge points[1]-points[2]<br></br>
+         * Solve a line segment using barycentric coordinates.
+         * Possible regions:
+         * - points[2]
+         * - edge points[0]-points[2]
+         * - edge points[1]-points[2]
          * - inside the triangle
          */
         fun solve3() {
-            w1.set(m_v1.w)
-            w2.set(m_v2.w)
-            w3.set(m_v3.w)
+            w1.set(v1.w)
+            w2.set(v2.w)
+            w3.set(v3.w)
 
             // Edge12
             // [1 1 ][a1] = [1]
@@ -416,196 +403,174 @@ class Distance(val stats: Stats = Stats()) {
 
             // w1 region
             if (d12_2 <= 0.0f && d13_2 <= 0.0f) {
-                m_v1.a = 1.0f
-                m_count = 1
+                v1.a = 1.0f
+                count = 1
                 return
             }
 
             // e12
             if (d12_1 > 0.0f && d12_2 > 0.0f && d123_3 <= 0.0f) {
                 val inv_d12 = 1.0f / (d12_1 + d12_2)
-                m_v1.a = d12_1 * inv_d12
-                m_v2.a = d12_2 * inv_d12
-                m_count = 2
+                v1.a = d12_1 * inv_d12
+                v2.a = d12_2 * inv_d12
+                count = 2
                 return
             }
 
             // e13
             if (d13_1 > 0.0f && d13_2 > 0.0f && d123_2 <= 0.0f) {
                 val inv_d13 = 1.0f / (d13_1 + d13_2)
-                m_v1.a = d13_1 * inv_d13
-                m_v3.a = d13_2 * inv_d13
-                m_count = 2
-                m_v2.set(m_v3)
+                v1.a = d13_1 * inv_d13
+                v3.a = d13_2 * inv_d13
+                count = 2
+                v2.set(v3)
                 return
             }
 
             // w2 region
             if (d12_1 <= 0.0f && d23_2 <= 0.0f) {
-                m_v2.a = 1.0f
-                m_count = 1
-                m_v1.set(m_v2)
+                v2.a = 1.0f
+                count = 1
+                v1.set(v2)
                 return
             }
 
             // w3 region
             if (d13_1 <= 0.0f && d23_1 <= 0.0f) {
-                m_v3.a = 1.0f
-                m_count = 1
-                m_v1.set(m_v3)
+                v3.a = 1.0f
+                count = 1
+                v1.set(v3)
                 return
             }
 
             // e23
             if (d23_1 > 0.0f && d23_2 > 0.0f && d123_1 <= 0.0f) {
                 val inv_d23 = 1.0f / (d23_1 + d23_2)
-                m_v2.a = d23_1 * inv_d23
-                m_v3.a = d23_2 * inv_d23
-                m_count = 2
-                m_v1.set(m_v3)
+                v2.a = d23_1 * inv_d23
+                v3.a = d23_2 * inv_d23
+                count = 2
+                v1.set(v3)
                 return
             }
 
             // Must be in triangle123
             val inv_d123 = 1.0f / (d123_1 + d123_2 + d123_3)
-            m_v1.a = d123_1 * inv_d123
-            m_v2.a = d123_2 * inv_d123
-            m_v3.a = d123_3 * inv_d123
-            m_count = 3
+            v1.a = d123_1 * inv_d123
+            v2.a = d123_2 * inv_d123
+            v3.a = d123_3 * inv_d123
+            count = 3
         }
     }
 
     /**
-     * A distance proxy is used by the GJK algorithm. It encapsulates any shape. TODO: see if we can
-     * just do assignments with m_vertices, instead of copying stuff over
+     * A distance proxy is used by the GJK algorithm. It encapsulates any shape.
+     * TODO: see if we can just do assignments with m_vertices, instead of copying stuff over
      *
      * @author daniel
      */
     class DistanceProxy {
 
-        val m_vertices: Array<Vec2> = Array(Settings.maxPolygonVertices) { Vec2() }
-        /**
-         * Get the vertex count.
-         *
-         * @return
-         */
+        val vertices: Array<Vec2> = Array(Settings.maxPolygonVertices) { Vec2() }
 
         var vertexCount: Int = 0
 
-        var m_radius: Float = 0f
+        var radius: Float = 0f
 
-        val m_buffer: Array<Vec2> = Array(2) { Vec2() }
+        val buffer: Array<Vec2> = Array(2) { Vec2() }
 
         /**
          * Initialize the proxy using the given shape. The shape must remain in scope while the proxy is
          * in use.
          */
         fun set(shape: Shape, index: Int) {
-            when (shape.getType()) {
+            when (shape.type) {
                 ShapeType.CIRCLE -> {
                     val circle = shape as CircleShape
-                    m_vertices[0].set(circle.m_p)
+                    vertices[0].set(circle.p)
                     vertexCount = 1
-                    m_radius = circle.m_radius
+                    radius = circle.radius
                 }
                 ShapeType.POLYGON -> {
                     val poly = shape as PolygonShape
-                    vertexCount = poly.m_count
-                    m_radius = poly.m_radius
+                    vertexCount = poly.vertexCount
+                    radius = poly.radius
                     for (i in 0 until vertexCount) {
-                        m_vertices[i].set(poly.m_vertices[i])
+                        vertices[i].set(poly.vertices[i])
                     }
                 }
                 ShapeType.CHAIN -> {
                     val chain = shape as ChainShape
-                    assert(0 <= index && index < chain.m_count)
+                    assert(0 <= index && index < chain.count)
 
-                    m_buffer[0] = chain.m_vertices!![index]
-                    if (index + 1 < chain.m_count) {
-                        m_buffer[1] = chain.m_vertices!![index + 1]
+                    buffer[0] = chain.vertices!![index]
+                    if (index + 1 < chain.count) {
+                        buffer[1] = chain.vertices!![index + 1]
                     } else {
-                        m_buffer[1] = chain.m_vertices!![0]
+                        buffer[1] = chain.vertices!![0]
                     }
 
-                    m_vertices[0].set(m_buffer[0])
-                    m_vertices[1].set(m_buffer[1])
+                    vertices[0].set(buffer[0])
+                    vertices[1].set(buffer[1])
                     vertexCount = 2
-                    m_radius = chain.m_radius
+                    radius = chain.radius
                 }
                 ShapeType.EDGE -> {
                     val edge = shape as EdgeShape
-                    m_vertices[0].set(edge.m_vertex1)
-                    m_vertices[1].set(edge.m_vertex2)
+                    vertices[0].set(edge.vertex1)
+                    vertices[1].set(edge.vertex2)
                     vertexCount = 2
-                    m_radius = edge.m_radius
+                    radius = edge.radius
                 }
-                else -> assert(false)
             }
         }
 
         /**
-         * Get the supporting vertex index in the given direction.
-         *
-         * @param d
-         * @return
+         * Get the supporting vertex index in the given direction [d].
          */
         fun getSupport(d: Vec2): Int {
             var bestIndex = 0
-            var bestValue = Vec2.dot(m_vertices[0], d)
+            var bestValue = Vec2.dot(vertices[0], d)
             for (i in 1 until vertexCount) {
-                val value = Vec2.dot(m_vertices[i], d)
+                val value = Vec2.dot(vertices[i], d)
                 if (value > bestValue) {
                     bestIndex = i
                     bestValue = value
                 }
             }
-
             return bestIndex
         }
 
         /**
-         * Get the supporting vertex in the given direction.
-         *
-         * @param d
-         * @return
+         * Get the supporting vertex in the given direction [d].
          */
         fun getSupportVertex(d: Vec2): Vec2 {
             var bestIndex = 0
-            var bestValue = Vec2.dot(m_vertices[0], d)
+            var bestValue = Vec2.dot(vertices[0], d)
             for (i in 1 until vertexCount) {
-                val value = Vec2.dot(m_vertices[i], d)
+                val value = Vec2.dot(vertices[i], d)
                 if (value > bestValue) {
                     bestIndex = i
                     bestValue = value
                 }
             }
-
-            return m_vertices[bestIndex]
+            return vertices[bestIndex]
         }
 
         /**
-         * Get a vertex by index. Used by Distance.
-         *
-         * @param index
-         * @return
+         * Get a vertex by [index]. Used by Distance.
          */
         fun getVertex(index: Int): Vec2 {
-            assert(0 <= index && index < vertexCount)
-            return m_vertices[index]
+            assert(index in 0 until vertexCount)
+            return vertices[index]
         }
     }
 
     /**
-     * Compute the closest points between two shapes. Supports any combination of: CircleShape and
+     * Compute the closest points between two shapes. Supports any combination of CircleShape and
      * PolygonShape. The simplex cache is input/output. On the first call set SimplexCache.count to
      * zero.
-     *
-     * @param output
-     * @param cache
-     * @param input
      */
-    fun distance(output: DistanceOutput, cache: SimplexCache,
-                 input: DistanceInput) {
+    fun distance(output: DistanceOutput, cache: SimplexCache, input: DistanceInput) {
         stats.GJK_CALLS++
 
         val proxyA = input.proxyA
@@ -634,24 +599,21 @@ class Distance(val stats: Stats = Stats()) {
         while (iter < MAX_ITERS) {
 
             // Copy simplex so we can identify duplicates.
-            saveCount = simplex.m_count
+            saveCount = simplex.count
             for (i in 0 until saveCount) {
                 saveA[i] = vertices[i].indexA
                 saveB[i] = vertices[i].indexB
             }
 
-            when (simplex.m_count) {
-                1 -> {
-                }
+            when (simplex.count) {
+                1 -> Unit
                 2 -> simplex.solve2()
                 3 -> simplex.solve3()
                 else -> assert(false)
             }
 
             // If we have 3 points, then the origin is in the corresponding triangle.
-            if (simplex.m_count == 3) {
-                break
-            }
+            if (simplex.count == 3) break
 
             // Compute closest point.
             simplex.getClosestPoint(closestPoint)
@@ -677,15 +639,15 @@ class Distance(val stats: Stats = Stats()) {
                 break
             }
             /*
-       * SimplexVertex* vertex = vertices + simplex.m_count; vertex.indexA =
-       * proxyA.GetSupport(MulT(transformA.R, -d)); vertex.wA = Mul(transformA,
-       * proxyA.GetVertex(vertex.indexA)); Vec2 wBLocal; vertex.indexB =
-       * proxyB.GetSupport(MulT(transformB.R, d)); vertex.wB = Mul(transformB,
-       * proxyB.GetVertex(vertex.indexB)); vertex.w = vertex.wB - vertex.wA;
-       */
+            SimplexVertex* vertex = vertices + simplex.m_count; vertex.indexA =
+            proxyA.GetSupport(MulT(transformA.R, -d)); vertex.wA = Mul(transformA,
+            proxyA.GetVertex(vertex.indexA)); Vec2 wBLocal; vertex.indexB =
+            proxyB.GetSupport(MulT(transformB.R, d)); vertex.wB = Mul(transformB,
+            proxyB.GetVertex(vertex.indexB)); vertex.w = vertex.wB - vertex.wA;
+            */
 
             // Compute a tentative new simplex vertex using support points.
-            val vertex = vertices[simplex.m_count]
+            val vertex = vertices[simplex.count]
 
             Rot.mulTransUnsafe(transformA.q, d.negateLocal(), temp)
             vertex.indexA = proxyA.getSupport(temp)
@@ -710,12 +672,10 @@ class Distance(val stats: Stats = Stats()) {
             }
 
             // If we found a duplicate support point we must exit to avoid cycling.
-            if (duplicate) {
-                break
-            }
+            if (duplicate) break
 
             // New vertex is ok and needed.
-            ++simplex.m_count
+            ++simplex.count
         }
 
         stats.GJK_MAX_ITERS = MathUtils.max(stats.GJK_MAX_ITERS, iter)
@@ -730,8 +690,8 @@ class Distance(val stats: Stats = Stats()) {
 
         // Apply radii if requested.
         if (input.useRadii) {
-            val rA = proxyA.m_radius
-            val rB = proxyB.m_radius
+            val rA = proxyA.radius
+            val rB = proxyB.radius
 
             if (output.distance > rA + rB && output.distance > Settings.EPSILON) {
                 // Shapes are still no overlapped.
@@ -755,16 +715,12 @@ class Distance(val stats: Stats = Stats()) {
     }
 
     companion object {
-
         val MAX_ITERS = 20
-
     }
 
     class Stats {
         var GJK_CALLS = 0
-
         var GJK_ITERS = 0
-
         var GJK_MAX_ITERS = 20
     }
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/DistanceInput.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/DistanceInput.kt
@@ -30,16 +30,13 @@ import org.jbox2d.common.Transform
  * Input for Distance.
  * You have to option to use the shape radii
  * in the computation.
- *
  */
 class DistanceInput {
 
     var proxyA = DistanceProxy()
-
     var proxyB = DistanceProxy()
 
     var transformA = Transform()
-
     var transformB = Transform()
 
     var useRadii: Boolean = false

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/DistanceOutput.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/DistanceOutput.kt
@@ -30,18 +30,14 @@ import org.jbox2d.common.Vec2
  * @author Daniel
  */
 class DistanceOutput {
+
     /** Closest point on shapeA  */
-
     val pointA = Vec2()
-
     /** Closest point on shapeB  */
-
     val pointB = Vec2()
-
 
     var distance: Float = 0.toFloat()
 
     /** number of gjk iterations used  */
-
     var iterations: Int = 0
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/Manifold.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/Manifold.kt
@@ -51,22 +51,17 @@ import org.jbox2d.common.Vec2
 class Manifold {
 
     /** The points of contact.  */
-
     val points: Array<ManifoldPoint>
 
     /** not use for Type::e_points  */
-
     val localNormal: Vec2
 
     /** usage depends on manifold type  */
-
     val localPoint: Vec2
-
 
     var type: ManifoldType = ManifoldType.CIRCLES
 
     /** The number of manifold points.  */
-
     var pointCount: Int = 0
 
     enum class ManifoldType {
@@ -74,7 +69,7 @@ class Manifold {
     }
 
     /**
-     * creates a manifold with 0 points, with it's points array full of instantiated ManifoldPoints.
+     * creates a manifold with 0 points, with its points array full of instantiated ManifoldPoints.
      */
     constructor() {
         points = Array(Settings.maxManifoldPoints) { ManifoldPoint() }
@@ -84,9 +79,7 @@ class Manifold {
     }
 
     /**
-     * Creates this manifold as a copy of the other
-     *
-     * @param other
+     * Creates this manifold as a copy of the [other]
      */
     constructor(other: Manifold) {
         localNormal = other.localNormal.clone()
@@ -98,9 +91,7 @@ class Manifold {
     }
 
     /**
-     * copies this manifold from the given one
-     *
-     * @param cp manifold to copy from
+     * copies this manifold from the given manifold [cp]
      */
     fun set(cp: Manifold) {
         for (i in 0 until cp.pointCount) {

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/ManifoldPoint.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/ManifoldPoint.kt
@@ -43,12 +43,10 @@
  * misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  */
-
 package org.jbox2d.collision
 
 import org.jbox2d.common.Vec2
 
-// updated to rev 100
 /**
  * A manifold point is a contact point belonging to a contact
  * manifold. It holds details related to the geometry and dynamics
@@ -62,17 +60,17 @@ import org.jbox2d.common.Vec2
  * provide reliable contact forces, especially for high speed collisions.
  */
 class ManifoldPoint {
+
     /** usage depends on manifold type  */
-
     val localPoint: Vec2
+
     /** the non-penetration impulse  */
-
     var normalImpulse: Float = 0.toFloat()
+
     /** the friction impulse  */
-
     var tangentImpulse: Float = 0.toFloat()
-    /** uniquely identifies a contact point between two shapes  */
 
+    /** uniquely identifies a contact point between two shapes  */
     val id: ContactID
 
     /**
@@ -86,8 +84,7 @@ class ManifoldPoint {
     }
 
     /**
-     * Creates a manifold point as a copy of the given point
-     * @param cp point to copy from
+     * Creates a manifold point as a copy of the given point [cp]
      */
     constructor(cp: ManifoldPoint) {
         localPoint = cp.localPoint.clone()
@@ -97,8 +94,7 @@ class ManifoldPoint {
     }
 
     /**
-     * Sets this manifold point form the given one
-     * @param cp the point to copy from
+     * Sets this manifold point form the given point [cp]
      */
     fun set(cp: ManifoldPoint) {
         localPoint.set(cp.localPoint)

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/RayCastInput.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/RayCastInput.kt
@@ -25,23 +25,15 @@ package org.jbox2d.collision
 
 import org.jbox2d.common.Vec2
 
-// updated to rev 100
 /**
  * Ray-cast input data. The ray extends from p1 to p1 + maxFraction * (p2 - p1).
  */
 class RayCastInput {
 
-    val p1: Vec2
+    val p1: Vec2 = Vec2()
+    val p2: Vec2 = Vec2()
 
-    val p2: Vec2
-
-    var maxFraction: Float = 0.toFloat()
-
-    init {
-        p1 = Vec2()
-        p2 = Vec2()
-        maxFraction = 0f
-    }
+    var maxFraction: Float = 0f
 
     fun set(rci: RayCastInput) {
         p1.set(rci.p1)

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/RayCastOutput.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/RayCastOutput.kt
@@ -25,21 +25,14 @@ package org.jbox2d.collision
 
 import org.jbox2d.common.Vec2
 
-// updated to rev 100
 /**
  * Ray-cast output data. The ray hits at p1 + fraction * (p2 - p1), where p1 and p2
  * come from b2RayCastInput.
  */
 class RayCastOutput {
 
-    val normal: Vec2
-
-    var fraction: Float = 0.toFloat()
-
-    init {
-        normal = Vec2()
-        fraction = 0f
-    }
+    val normal = Vec2()
+    var fraction: Float = 0f
 
     fun set(rco: RayCastOutput) {
         normal.set(rco.normal)

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/WorldManifold.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/WorldManifold.kt
@@ -35,32 +35,30 @@ import org.jbox2d.common.Vec2
  * @author daniel
  */
 class WorldManifold {
+
     /**
      * World vector pointing from A to B
      */
-
     val normal: Vec2 = Vec2()
 
     /**
      * World contact point (point of intersection)
      */
-
     val points: Array<Vec2> = Array(Settings.maxManifoldPoints) { Vec2() }
 
     /**
      * A negative value indicates overlap, in meters.
      */
-
     val separations: FloatArray = FloatArray(Settings.maxManifoldPoints)
 
     private val pool3 = Vec2()
     private val pool4 = Vec2()
 
-    fun initialize(manifold: Manifold, xfA: Transform, radiusA: Float,
-                   xfB: Transform, radiusB: Float) {
-        if (manifold.pointCount == 0) {
-            return
-        }
+    fun initialize(
+        manifold: Manifold, xfA: Transform, radiusA: Float,
+        xfB: Transform, radiusB: Float
+    ) {
+        if (manifold.pointCount == 0) return
 
         when (manifold.type) {
             Manifold.ManifoldType.CIRCLES -> {
@@ -116,7 +114,8 @@ class WorldManifold {
                     // cB.set(normal).mulLocal(radiusB).subLocal(clipPoint).negateLocal();
                     // points[i].set(cA).addLocal(cB).mulLocal(0.5f);
 
-                    val scalar = radiusA - ((clipPoint.x - planePoint.x) * normal.x + (clipPoint.y - planePoint.y) * normal.y)
+                    val scalar =
+                        radiusA - ((clipPoint.x - planePoint.x) * normal.x + (clipPoint.y - planePoint.y) * normal.y)
 
                     val cAx = normal.x * scalar + clipPoint.x
                     val cAy = normal.y * scalar + clipPoint.y
@@ -165,7 +164,8 @@ class WorldManifold {
                     // clipPoint.y = xfA.p.y + xfA.q.ex.y * manifold.points[i].localPoint.x + xfA.q.ey.y *
                     // manifold.points[i].localPoint.y;
 
-                    val scalar = radiusB - ((clipPoint.x - planePoint.x) * normal.x + (clipPoint.y - planePoint.y) * normal.y)
+                    val scalar =
+                        radiusB - ((clipPoint.x - planePoint.x) * normal.x + (clipPoint.y - planePoint.y) * normal.y)
 
                     val cBx = normal.x * scalar + clipPoint.x
                     val cBy = normal.y * scalar + clipPoint.y

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/broadphase/BroadPhase.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/broadphase/BroadPhase.kt
@@ -8,21 +8,12 @@ import org.jbox2d.collision.AABB
 import org.jbox2d.collision.RayCastInput
 import org.jbox2d.common.Vec2
 
-
 interface BroadPhase {
 
-    /**
-     * Get the number of proxies.
-     *
-     * @return
-     */
+    /** Number of proxies. */
     val proxyCount: Int
 
-    /**
-     * Get the height of the embedded tree.
-     *
-     * @return
-     */
+    /** Height of the embedded tree. */
     val treeHeight: Int
 
     val treeBalance: Int
@@ -30,23 +21,17 @@ interface BroadPhase {
     val treeQuality: Float
 
     /**
-     * Create a proxy with an initial AABB. Pairs are not reported until updatePairs is called.
-     *
-     * @param aabb
-     * @param userData
-     * @return
+     * Create a proxy with an initial [aabb]. Pairs are not reported until [updatePairs] is called.
      */
     fun createProxy(aabb: AABB, userData: Any): Int
 
     /**
      * Destroy a proxy. It is up to the client to remove any pairs.
-     *
-     * @param proxyId
      */
     fun destroyProxy(proxyId: Int)
 
     /**
-     * Call MoveProxy as many times as you like, then when you are done call UpdatePairs to finalized
+     * Call [moveProxy] as many times as you like, then when you are done call [updatePairs] to finalize
      * the proxy pairs (for your time step).
      */
     fun moveProxy(proxyId: Int, aabb: AABB, displacement: Vec2)
@@ -63,23 +48,18 @@ interface BroadPhase {
 
     /**
      * Update the pairs. This results in pair callbacks. This can only add pairs.
-     *
-     * @param callback
      */
     fun updatePairs(callback: PairCallback)
 
     /**
-     * Query an AABB for overlapping proxies. The callback class is called for each proxy that
-     * overlaps the supplied AABB.
-     *
-     * @param callback
-     * @param aabb
+     * Query an [aabb] for overlapping proxies. The [callback] is called for each proxy that
+     * overlaps the supplied [aabb].
      */
     fun query(callback: TreeCallback, aabb: AABB)
 
     /**
-     * Ray-cast against the proxies in the tree. This relies on the callback to perform a exact
-     * ray-cast in the case were the proxy contains a shape. The callback also performs the any
+     * Ray-cast against the proxies in the tree. This relies on the callback to perform an exact
+     * ray-cast in the case where the proxy contains a shape. The callback also performs the any
      * collision filtering. This has performance roughly equal to k * log(n), where k is the number of
      * collisions and n is the number of proxies in the tree.
      *
@@ -89,8 +69,6 @@ interface BroadPhase {
     fun raycast(callback: TreeRayCastCallback, input: RayCastInput)
 
     companion object {
-
-
         val NULL_PROXY = -1
     }
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/broadphase/BroadPhaseStrategy.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/broadphase/BroadPhaseStrategy.kt
@@ -11,44 +11,32 @@ interface BroadPhaseStrategy {
 
     /**
      * Compute the height of the binary tree in O(N) time. Should not be called often.
-     *
-     * @return
      */
     val height: Int
 
     /**
-     * Get the maximum balance of an node in the tree. The balance is the difference in height of the
+     * The maximum balance of a node in the tree. The balance is the difference in height of
      * two children of a node.
-     *
-     * @return
      */
     val maxBalance: Int
 
     /**
-     * Get the ratio of the sum of the node areas to the root area.
-     *
-     * @return
+     * The ratio of the sum of the node areas to the root area.
      */
     val areaRatio: Float
 
     /**
-     * Create a proxy. Provide a tight fitting AABB and a userData pointer.
-     *
-     * @param aabb
-     * @param userData
-     * @return
+     * Create a proxy. Provide a tight fitting [aabb] and a [userData] pointer.
      */
     fun createProxy(aabb: AABB, userData: Any): Int
 
     /**
      * Destroy a proxy
-     *
-     * @param proxyId
      */
     fun destroyProxy(proxyId: Int)
 
     /**
-     * Move a proxy with a swepted AABB. If the proxy has moved outside of its fattened AABB, then the
+     * Move a proxy with a swepted [aabb]. If the proxy has moved outside of its fattened [AABB], then the
      * proxy is removed from the tree and re-inserted. Otherwise the function returns immediately.
      *
      * @return true if the proxy was re-inserted.
@@ -60,17 +48,14 @@ interface BroadPhaseStrategy {
     fun getFatAABB(proxyId: Int): AABB
 
     /**
-     * Query an AABB for overlapping proxies. The callback class is called for each proxy that
-     * overlaps the supplied AABB.
-     *
-     * @param callback
-     * @param araabbgAABB
+     * Query an AABB for overlapping proxies. The [callback] is called for each proxy that
+     * overlaps the supplied [aabb].
      */
     fun query(callback: TreeCallback, aabb: AABB)
 
     /**
-     * Ray-cast against the proxies in the tree. This relies on the callback to perform a exact
-     * ray-cast in the case were the proxy contains a shape. The callback also performs the any
+     * Ray-cast against the proxies in the tree. This relies on the callback to perform an exact
+     * ray-cast in the case where the proxy contains a shape. The callback also performs the any
      * collision filtering. This has performance roughly equal to k * log(n), where k is the number of
      * collisions and n is the number of proxies in the tree.
      *

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/broadphase/DynamicTreeFlatNodes.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/broadphase/DynamicTreeFlatNodes.kt
@@ -34,25 +34,23 @@ import org.jbox2d.common.MathUtils
 import org.jbox2d.common.Settings
 import org.jbox2d.common.Vec2
 import org.jbox2d.internal.*
-import kotlin.reflect.*
 
 class DynamicTreeFlatNodes : BroadPhaseStrategy {
 
+    var root: Int = NULL_NODE
+    lateinit var aabbs: Array<AABB>
+    lateinit var userDatas: Array<Any?>
+    lateinit protected var parents: IntArray
+    lateinit protected var children1: IntArray
+    lateinit protected var children2: IntArray
+    lateinit protected var heights: IntArray
 
-    var m_root: Int = NULL_NODE
-    lateinit var m_aabb: Array<AABB>
-    lateinit var m_userData: Array<Any?>
-    lateinit protected var m_parent: IntArray
-    lateinit protected var m_child1: IntArray
-    lateinit protected var m_child2: IntArray
-    lateinit protected var m_height: IntArray
+    private var nodeCount: Int = 0
+    private var nodeCapacity: Int = 16
 
-    private var m_nodeCount: Int = 0
-    private var m_nodeCapacity: Int = 16
+    private var freeList: Int = 0
 
-    private var m_freeList: Int = 0
-
-    private val drawVecs = Array<Vec2>(4) { Vec2() }
+    private val drawVecs = Array(4) { Vec2() }
 
     private var nodeStack = IntArray(20)
     private var nodeStackIndex: Int = 0
@@ -62,46 +60,37 @@ class DynamicTreeFlatNodes : BroadPhaseStrategy {
     private val subInput = RayCastInput()
 
     override val height: Int
-        get() = if (m_root == NULL_NODE) {
-            0
-        } else m_height[m_root]
+        get() = if (root == NULL_NODE) 0 else heights[root]
 
     override val maxBalance: Int
         get() {
             var maxBalance = 0
-            for (i in 0 until m_nodeCapacity) {
-                if (m_height[i] <= 1) {
-                    continue
-                }
+            for (i in 0 until nodeCapacity) {
+                if (heights[i] <= 1) continue
 
-                assert(m_child1[i] != NULL_NODE)
+                assert(children1[i] != NULL_NODE)
 
-                val child1 = m_child1[i]
-                val child2 = m_child2[i]
-                val balance = MathUtils.abs(m_height[child2] - m_height[child1])
+                val child1 = children1[i]
+                val child2 = children2[i]
+                val balance = MathUtils.abs(heights[child2] - heights[child1])
                 maxBalance = MathUtils.max(maxBalance, balance)
             }
-
             return maxBalance
         }
 
-    override// Free node in pool
-    val areaRatio: Float
+    override val areaRatio: Float
         get() {
-            if (m_root == NULL_NODE) {
-                return 0.0f
-            }
+            if (root == NULL_NODE) return 0.0f
 
-            val root = m_root
-            val rootArea = m_aabb[root].perimeter
+            val root = root
+            val rootArea = aabbs[root].perimeter
 
             var totalArea = 0.0f
-            for (i in 0 until m_nodeCapacity) {
-                if (m_height[i] < 0) {
-                    continue
-                }
+            for (i in 0 until nodeCapacity) {
+                // Free node in pool
+                if (heights[i] < 0) continue
 
-                totalArea += m_aabb[i].perimeter
+                totalArea += aabbs[i].perimeter
             }
 
             return totalArea / rootArea
@@ -113,37 +102,37 @@ class DynamicTreeFlatNodes : BroadPhaseStrategy {
     private val textVec = Vec2()
 
     init {
-        expandBuffers(0, m_nodeCapacity)
+        expandBuffers(0, nodeCapacity)
     }
 
     private fun expandBuffers(oldSize: Int, newSize: Int) {
-        m_aabb = BufferUtils.reallocateBuffer({ AABB() }, m_aabb, oldSize, newSize)
-        m_userData = BufferUtils.reallocateBuffer<Any>({ Any() }, m_userData as Array<Any>, oldSize, newSize) as Array<Any?>
-        m_parent = BufferUtils.reallocateBuffer(m_parent, oldSize, newSize)
-        m_child1 = BufferUtils.reallocateBuffer(m_child1, oldSize, newSize)
-        m_child2 = BufferUtils.reallocateBuffer(m_child2, oldSize, newSize)
-        m_height = BufferUtils.reallocateBuffer(m_height, oldSize, newSize)
+        aabbs = BufferUtils.reallocateBuffer({ AABB() }, aabbs, oldSize, newSize)
+        userDatas = BufferUtils.reallocateBuffer({ Any() }, userDatas as Array<Any>, oldSize, newSize) as Array<Any?>
+        parents = BufferUtils.reallocateBuffer(parents, oldSize, newSize)
+        children1 = BufferUtils.reallocateBuffer(children1, oldSize, newSize)
+        children2 = BufferUtils.reallocateBuffer(children2, oldSize, newSize)
+        heights = BufferUtils.reallocateBuffer(heights, oldSize, newSize)
 
         // Build a linked list for the free list.
         for (i in oldSize until newSize) {
-            m_aabb[i] = AABB()
-            m_parent[i] = if (i == newSize - 1) NULL_NODE else i + 1
-            m_height[i] = -1
-            m_child1[i] = -1
-            m_child2[i] = -1
+            aabbs[i] = AABB()
+            parents[i] = if (i == newSize - 1) NULL_NODE else i + 1
+            heights[i] = -1
+            children1[i] = -1
+            children2[i] = -1
         }
-        m_freeList = oldSize
+        freeList = oldSize
     }
 
     override fun createProxy(aabb: AABB, userData: Any): Int {
         val node = allocateNode()
         // Fatten the aabb
-        val nodeAABB = m_aabb[node]
+        val nodeAABB = aabbs[node]
         nodeAABB.lowerBound.x = aabb.lowerBound.x - Settings.aabbExtension
         nodeAABB.lowerBound.y = aabb.lowerBound.y - Settings.aabbExtension
         nodeAABB.upperBound.x = aabb.upperBound.x + Settings.aabbExtension
         nodeAABB.upperBound.y = aabb.upperBound.y + Settings.aabbExtension
-        m_userData[node] = userData
+        userDatas[node] = userData
 
         insertLeaf(node)
 
@@ -151,24 +140,20 @@ class DynamicTreeFlatNodes : BroadPhaseStrategy {
     }
 
     override fun destroyProxy(proxyId: Int) {
-        assert(0 <= proxyId && proxyId < m_nodeCapacity)
-        assert(m_child1[proxyId] == NULL_NODE)
+        assert(proxyId in 0 until nodeCapacity)
+        assert(children1[proxyId] == NULL_NODE)
 
         removeLeaf(proxyId)
         freeNode(proxyId)
     }
 
     override fun moveProxy(proxyId: Int, aabb: AABB, displacement: Vec2): Boolean {
-        assert(0 <= proxyId && proxyId < m_nodeCapacity)
+        assert(proxyId in 0 until nodeCapacity)
         val node = proxyId
-        assert(m_child1[node] == NULL_NODE)
+        assert(children1[node] == NULL_NODE)
 
-        val nodeAABB = m_aabb[node]
-        // if (nodeAABB.contains(aabb)) {
-        if (nodeAABB.lowerBound.x <= aabb.lowerBound.x && nodeAABB.lowerBound.y <= aabb.lowerBound.y
-                && aabb.upperBound.x <= nodeAABB.upperBound.x && aabb.upperBound.y <= nodeAABB.upperBound.y) {
-            return false
-        }
+        val nodeAABB = aabbs[node]
+        if (nodeAABB.contains(aabb)) return false
 
         removeLeaf(node)
 
@@ -200,38 +185,34 @@ class DynamicTreeFlatNodes : BroadPhaseStrategy {
     }
 
     override fun getUserData(proxyId: Int): Any? {
-        assert(0 <= proxyId && proxyId < m_nodeCount)
-        return m_userData[proxyId]
+        assert(proxyId in 0 until nodeCount)
+        return userDatas[proxyId]
     }
 
     override fun getFatAABB(proxyId: Int): AABB {
-        assert(0 <= proxyId && proxyId < m_nodeCount)
-        return m_aabb[proxyId]
+        assert(proxyId in 0 until nodeCount)
+        return aabbs[proxyId]
     }
 
     override fun query(callback: TreeCallback, aabb: AABB) {
         nodeStackIndex = 0
-        nodeStack[nodeStackIndex++] = m_root
+        nodeStack[nodeStackIndex++] = root
 
         while (nodeStackIndex > 0) {
             val node = nodeStack[--nodeStackIndex]
-            if (node == NULL_NODE) {
-                continue
-            }
+            if (node == NULL_NODE) continue
 
-            if (AABB.testOverlap(m_aabb[node], aabb)) {
-                val child1 = m_child1[node]
+            if (AABB.testOverlap(aabbs[node], aabb)) {
+                val child1 = children1[node]
                 if (child1 == NULL_NODE) {
                     val proceed = callback.treeCallback(node)
-                    if (!proceed) {
-                        return
-                    }
+                    if (!proceed) return
                 } else {
                     if (nodeStack.size - nodeStackIndex - 2 <= 0) {
                         nodeStack = BufferUtils.reallocateBuffer(nodeStack, nodeStack.size, nodeStack.size * 2)
                     }
                     nodeStack[nodeStackIndex++] = child1
-                    nodeStack[nodeStackIndex++] = m_child2[node]
+                    nodeStack[nodeStackIndex++] = children2[node]
                 }
             }
         }
@@ -244,30 +225,18 @@ class DynamicTreeFlatNodes : BroadPhaseStrategy {
         val p2x = p2.x
         val p1y = p1.y
         val p2y = p2.y
-        val vx: Float
-        val vy: Float
-        val rx: Float
-        val ry: Float
-        val absVx: Float
-        val absVy: Float
-        var cx: Float
-        var cy: Float
-        var hx: Float
-        var hy: Float
-        var tempx: Float
-        var tempy: Float
         r.x = p2x - p1x
         r.y = p2y - p1y
         assert(r.x * r.x + r.y * r.y > 0f)
         r.normalize()
-        rx = r.x
-        ry = r.y
+        val rx = r.x
+        val ry = r.y
 
         // v is perpendicular to the segment.
-        vx = -1f * ry
-        vy = 1f * rx
-        absVx = MathUtils.abs(vx)
-        absVy = MathUtils.abs(vy)
+        val vx = -1f * ry
+        val vy = 1f * rx
+        val absVx = MathUtils.abs(vx)
+        val absVy = MathUtils.abs(vy)
 
         // Separating axis for segment (Gino, p80).
         // |dot(v, p1 - c)| > dot(|v|, h)
@@ -281,8 +250,8 @@ class DynamicTreeFlatNodes : BroadPhaseStrategy {
         // temp.set(p2).subLocal(p1).mulLocal(maxFraction).addLocal(p1);
         // Vec2.minToOut(p1, temp, segAABB.lowerBound);
         // Vec2.maxToOut(p1, temp, segAABB.upperBound);
-        tempx = (p2x - p1x) * maxFraction + p1x
-        tempy = (p2y - p1y) * maxFraction + p1y
+        var tempx = (p2x - p1x) * maxFraction + p1x
+        var tempy = (p2y - p1y) * maxFraction + p1y
         segAABB.lowerBound.x = if (p1x < tempx) p1x else tempx
         segAABB.lowerBound.y = if (p1y < tempy) p1y else tempy
         segAABB.upperBound.x = if (p1x > tempx) p1x else tempx
@@ -290,15 +259,13 @@ class DynamicTreeFlatNodes : BroadPhaseStrategy {
         // end inline
 
         nodeStackIndex = 0
-        nodeStack[nodeStackIndex++] = m_root
+        nodeStack[nodeStackIndex++] = root
         while (nodeStackIndex > 0) {
-            nodeStack[--nodeStackIndex] = m_root
+            nodeStack[--nodeStackIndex] = root
             val node = nodeStack[--nodeStackIndex]
-            if (node == NULL_NODE) {
-                continue
-            }
+            if (node == NULL_NODE) continue
 
-            val nodeAABB = m_aabb[node]
+            val nodeAABB = aabbs[node]
             if (!AABB.testOverlap(nodeAABB, segAABB)) {
                 continue
             }
@@ -307,18 +274,16 @@ class DynamicTreeFlatNodes : BroadPhaseStrategy {
             // |dot(v, p1 - c)| > dot(|v|, h)
             // node.aabb.getCenterToOut(c);
             // node.aabb.getExtentsToOut(h);
-            cx = (nodeAABB.lowerBound.x + nodeAABB.upperBound.x) * .5f
-            cy = (nodeAABB.lowerBound.y + nodeAABB.upperBound.y) * .5f
-            hx = (nodeAABB.upperBound.x - nodeAABB.lowerBound.x) * .5f
-            hy = (nodeAABB.upperBound.y - nodeAABB.lowerBound.y) * .5f
+            val cx = (nodeAABB.lowerBound.x + nodeAABB.upperBound.x) * .5f
+            val cy = (nodeAABB.lowerBound.y + nodeAABB.upperBound.y) * .5f
+            val hx = (nodeAABB.upperBound.x - nodeAABB.lowerBound.x) * .5f
+            val hy = (nodeAABB.upperBound.y - nodeAABB.lowerBound.y) * .5f
             tempx = p1x - cx
             tempy = p1y - cy
             val separation = MathUtils.abs(vx * tempx + vy * tempy) - (absVx * hx + absVy * hy)
-            if (separation > 0.0f) {
-                continue
-            }
+            if (separation > 0.0f) continue
 
-            val child1 = m_child1[node]
+            val child1 = children1[node]
             if (child1 == NULL_NODE) {
                 subInput.p1.x = p1x
                 subInput.p1.y = p1y
@@ -348,23 +313,21 @@ class DynamicTreeFlatNodes : BroadPhaseStrategy {
                 }
             } else {
                 nodeStack[nodeStackIndex++] = child1
-                nodeStack[nodeStackIndex++] = m_child2[node]
+                nodeStack[nodeStackIndex++] = children2[node]
             }
         }
     }
 
-    override fun computeHeight(): Int {
-        return computeHeight(m_root)
-    }
+    override fun computeHeight() = computeHeight(root)
 
     private fun computeHeight(node: Int): Int {
-        assert(0 <= node && node < m_nodeCapacity)
+        assert(node in 0 until nodeCapacity)
 
-        if (m_child1[node] == NULL_NODE) {
+        if (children1[node] == NULL_NODE) {
             return 0
         }
-        val height1 = computeHeight(m_child1[node])
-        val height2 = computeHeight(m_child2[node])
+        val height1 = computeHeight(children1[node])
+        val height2 = computeHeight(children2[node])
         return 1 + MathUtils.max(height1, height2)
     }
 
@@ -372,19 +335,19 @@ class DynamicTreeFlatNodes : BroadPhaseStrategy {
      * Validate this tree. For testing.
      */
     fun validate() {
-        validateStructure(m_root)
-        validateMetrics(m_root)
+        validateStructure(root)
+        validateMetrics(root)
 
         var freeCount = 0
-        var freeNode = m_freeList
+        var freeNode = freeList
         while (freeNode != NULL_NODE) {
-            assert(0 <= freeNode && freeNode < m_nodeCapacity)
-            freeNode = m_parent[freeNode]
+            assert(freeNode in 0 until nodeCapacity)
+            freeNode = parents[freeNode]
             ++freeCount
         }
 
         assert(height == computeHeight())
-        assert(m_nodeCount + freeCount == m_nodeCapacity)
+        assert(nodeCount + freeCount == nodeCapacity)
     }
 
     // /**
@@ -456,18 +419,18 @@ class DynamicTreeFlatNodes : BroadPhaseStrategy {
     // }
 
     private fun allocateNode(): Int {
-        if (m_freeList == NULL_NODE) {
-            assert(m_nodeCount == m_nodeCapacity)
-            m_nodeCapacity *= 2
-            expandBuffers(m_nodeCount, m_nodeCapacity)
+        if (freeList == NULL_NODE) {
+            assert(nodeCount == nodeCapacity)
+            nodeCapacity *= 2
+            expandBuffers(nodeCount, nodeCapacity)
         }
-        assert(m_freeList != NULL_NODE)
-        val node = m_freeList
-        m_freeList = m_parent[node]
-        m_parent[node] = NULL_NODE
-        m_child1[node] = NULL_NODE
-        m_height[node] = 0
-        ++m_nodeCount
+        assert(freeList != NULL_NODE)
+        val node = freeList
+        freeList = parents[node]
+        parents[node] = NULL_NODE
+        children1[node] = NULL_NODE
+        heights[node] = 0
+        ++nodeCount
         return node
     }
 
@@ -476,28 +439,28 @@ class DynamicTreeFlatNodes : BroadPhaseStrategy {
      */
     private fun freeNode(node: Int) {
         assert(node != NULL_NODE)
-        assert(0 < m_nodeCount)
-        m_parent[node] = if (m_freeList != NULL_NODE) m_freeList else NULL_NODE
-        m_height[node] = -1
-        m_freeList = node
-        m_nodeCount--
+        assert(0 < nodeCount)
+        parents[node] = if (freeList != NULL_NODE) freeList else NULL_NODE
+        heights[node] = -1
+        freeList = node
+        nodeCount--
     }
 
     private fun insertLeaf(leaf: Int) {
-        if (m_root == NULL_NODE) {
-            m_root = leaf
-            m_parent[m_root] = NULL_NODE
+        if (root == NULL_NODE) {
+            root = leaf
+            parents[root] = NULL_NODE
             return
         }
 
         // find the best sibling
-        val leafAABB = m_aabb[leaf]
-        var index = m_root
-        while (m_child1[index] != NULL_NODE) {
+        val leafAABB = aabbs[leaf]
+        var index = root
+        while (children1[index] != NULL_NODE) {
             val node = index
-            val child1 = m_child1[node]
-            val child2 = m_child2[node]
-            val nodeAABB = m_aabb[node]
+            val child1 = children1[node]
+            val child2 = children2[node]
+            val nodeAABB = aabbs[node]
             val area = nodeAABB.perimeter
 
             combinedAABB.combine(nodeAABB, leafAABB)
@@ -511,8 +474,8 @@ class DynamicTreeFlatNodes : BroadPhaseStrategy {
 
             // Cost of descending into child1
             val cost1: Float
-            val child1AABB = m_aabb[child1]
-            if (m_child1[child1] == NULL_NODE) {
+            val child1AABB = aabbs[child1]
+            if (children1[child1] == NULL_NODE) {
                 combinedAABB.combine(leafAABB, child1AABB)
                 cost1 = combinedAABB.perimeter + inheritanceCost
             } else {
@@ -524,8 +487,8 @@ class DynamicTreeFlatNodes : BroadPhaseStrategy {
 
             // Cost of descending into child2
             val cost2: Float
-            val child2AABB = m_aabb[child2]
-            if (m_child1[child2] == NULL_NODE) {
+            val child2AABB = aabbs[child2]
+            if (children1[child2] == NULL_NODE) {
                 combinedAABB.combine(leafAABB, child2AABB)
                 cost2 = combinedAABB.perimeter + inheritanceCost
             } else {
@@ -541,86 +504,77 @@ class DynamicTreeFlatNodes : BroadPhaseStrategy {
             }
 
             // Descend
-            if (cost1 < cost2) {
-                index = child1
-            } else {
-                index = child2
-            }
+            index = if (cost1 < cost2) child1 else child2
         }
 
         val sibling = index
-        val oldParent = m_parent[sibling]
+        val oldParent = parents[sibling]
         val newParent = allocateNode()
-        m_parent[newParent] = oldParent
-        m_userData[newParent] = null
-        m_aabb[newParent].combine(leafAABB, m_aabb[sibling])
-        m_height[newParent] = m_height[sibling] + 1
+        parents[newParent] = oldParent
+        userDatas[newParent] = null
+        aabbs[newParent].combine(leafAABB, aabbs[sibling])
+        heights[newParent] = heights[sibling] + 1
 
         if (oldParent != NULL_NODE) {
             // The sibling was not the root.
-            if (m_child1[oldParent] == sibling) {
-                m_child1[oldParent] = newParent
+            if (children1[oldParent] == sibling) {
+                children1[oldParent] = newParent
             } else {
-                m_child2[oldParent] = newParent
+                children2[oldParent] = newParent
             }
 
-            m_child1[newParent] = sibling
-            m_child2[newParent] = leaf
-            m_parent[sibling] = newParent
-            m_parent[leaf] = newParent
+            children1[newParent] = sibling
+            children2[newParent] = leaf
+            parents[sibling] = newParent
+            parents[leaf] = newParent
         } else {
             // The sibling was the root.
-            m_child1[newParent] = sibling
-            m_child2[newParent] = leaf
-            m_parent[sibling] = newParent
-            m_parent[leaf] = newParent
-            m_root = newParent
+            children1[newParent] = sibling
+            children2[newParent] = leaf
+            parents[sibling] = newParent
+            parents[leaf] = newParent
+            root = newParent
         }
 
         // Walk back up the tree fixing heights and AABBs
-        index = m_parent[leaf]
+        index = parents[leaf]
         while (index != NULL_NODE) {
             index = balance(index)
 
-            val child1 = m_child1[index]
-            val child2 = m_child2[index]
+            val child1 = children1[index]
+            val child2 = children2[index]
 
             assert(child1 != NULL_NODE)
             assert(child2 != NULL_NODE)
 
-            m_height[index] = 1 + MathUtils.max(m_height[child1], m_height[child2])
-            m_aabb[index].combine(m_aabb[child1], m_aabb[child2])
+            heights[index] = 1 + MathUtils.max(heights[child1], heights[child2])
+            aabbs[index].combine(aabbs[child1], aabbs[child2])
 
-            index = m_parent[index]
+            index = parents[index]
         }
         // validate();
     }
 
     private fun removeLeaf(leaf: Int) {
-        if (leaf == m_root) {
-            m_root = NULL_NODE
+        if (leaf == root) {
+            root = NULL_NODE
             return
         }
 
-        val parent = m_parent[leaf]
-        val grandParent = m_parent[parent]
-        val parentChild1 = m_child1[parent]
-        val parentChild2 = m_child2[parent]
-        val sibling: Int
-        if (parentChild1 == leaf) {
-            sibling = parentChild2
-        } else {
-            sibling = parentChild1
-        }
+        val parent = parents[leaf]
+        val grandParent = this.parents[parent]
+        val parentChild1 = children1[parent]
+        val parentChild2 = children2[parent]
+        val sibling = if (parentChild1 == leaf) parentChild2 else parentChild1
 
         if (grandParent != NULL_NODE) {
             // Destroy parent and connect sibling to grandParent.
-            if (m_child1[grandParent] == parent) {
-                m_child1[grandParent] = sibling
+            if (children1[grandParent] == parent) {
+                children1[grandParent] = sibling
             } else {
-                m_child2[grandParent] = sibling
+                children2[grandParent] = sibling
             }
-            m_parent[sibling] = grandParent
+            parents[sibling] = grandParent
             freeNode(parent)
 
             // Adjust ancestor bounds.
@@ -628,17 +582,17 @@ class DynamicTreeFlatNodes : BroadPhaseStrategy {
             while (index != NULL_NODE) {
                 index = balance(index)
 
-                val child1 = m_child1[index]
-                val child2 = m_child2[index]
+                val child1 = children1[index]
+                val child2 = children2[index]
 
-                m_aabb[index].combine(m_aabb[child1], m_aabb[child2])
-                m_height[index] = 1 + MathUtils.max(m_height[child1], m_height[child2])
+                aabbs[index].combine(aabbs[child1], aabbs[child2])
+                heights[index] = 1 + MathUtils.max(heights[child1], heights[child2])
 
-                index = m_parent[index]
+                index = this.parents[index]
             }
         } else {
-            m_root = sibling
-            m_parent[sibling] = NULL_NODE
+            root = sibling
+            parents[sibling] = NULL_NODE
             freeNode(parent)
         }
 
@@ -647,204 +601,189 @@ class DynamicTreeFlatNodes : BroadPhaseStrategy {
 
     // Perform a left or right rotation if node A is imbalanced.
     // Returns the new root index.
-    private fun balance(iA: Int): Int {
-        assert(iA != NULL_NODE)
+    private fun balance(A: Int): Int {
+        assert(A != NULL_NODE)
 
-        val A = iA
-        if (m_child1[A] == NULL_NODE || m_height[A] < 2) {
-            return iA
+        if (children1[A] == NULL_NODE || heights[A] < 2) {
+            return A
         }
 
-        val iB = m_child1[A]
-        val iC = m_child2[A]
-        assert(0 <= iB && iB < m_nodeCapacity)
-        assert(0 <= iC && iC < m_nodeCapacity)
+        val B = children1[A]
+        val C = children2[A]
+        assert(B in 0 until nodeCapacity)
+        assert(C in 0 until nodeCapacity)
 
-        val B = iB
-        val C = iC
-
-        val balance = m_height[C] - m_height[B]
+        val balance = heights[C] - heights[B]
 
         // Rotate C up
         if (balance > 1) {
-            val iF = m_child1[C]
-            val iG = m_child2[C]
-            val F = iF
-            val G = iG
+            val F = children1[C]
+            val G = children2[C]
             // assert (F != null);
             // assert (G != null);
-            assert(0 <= iF && iF < m_nodeCapacity)
-            assert(0 <= iG && iG < m_nodeCapacity)
+            assert(F in 0 until nodeCapacity)
+            assert(G in 0 until nodeCapacity)
 
             // Swap A and C
-            m_child1[C] = iA
-            m_parent[C] = m_parent[A]
-            val cParent = m_parent[C]
-            m_parent[A] = iC
+            children1[C] = A
+            parents[C] = parents[A]
+            val cParent = parents[C]
+            parents[A] = C
 
             // A's old parent should point to C
             if (cParent != NULL_NODE) {
-                if (m_child1[cParent] == iA) {
-                    m_child1[cParent] = iC
+                if (children1[cParent] == A) {
+                    children1[cParent] = C
                 } else {
-                    assert(m_child2[cParent] == iA)
-                    m_child2[cParent] = iC
+                    assert(children2[cParent] == A)
+                    children2[cParent] = C
                 }
             } else {
-                m_root = iC
+                root = C
             }
 
             // Rotate
-            if (m_height[F] > m_height[G]) {
-                m_child2[C] = iF
-                m_child2[A] = iG
-                m_parent[G] = iA
-                m_aabb[A].combine(m_aabb[B], m_aabb[G])
-                m_aabb[C].combine(m_aabb[A], m_aabb[F])
+            if (heights[F] > heights[G]) {
+                children2[C] = F
+                children2[A] = G
+                parents[G] = A
+                aabbs[A].combine(aabbs[B], aabbs[G])
+                aabbs[C].combine(aabbs[A], aabbs[F])
 
-                m_height[A] = 1 + MathUtils.max(m_height[B], m_height[G])
-                m_height[C] = 1 + MathUtils.max(m_height[A], m_height[F])
+                heights[A] = 1 + MathUtils.max(heights[B], heights[G])
+                heights[C] = 1 + MathUtils.max(heights[A], heights[F])
             } else {
-                m_child2[C] = iG
-                m_child2[A] = iF
-                m_parent[F] = iA
-                m_aabb[A].combine(m_aabb[B], m_aabb[F])
-                m_aabb[C].combine(m_aabb[A], m_aabb[G])
+                children2[C] = G
+                children2[A] = F
+                parents[F] = A
+                aabbs[A].combine(aabbs[B], aabbs[F])
+                aabbs[C].combine(aabbs[A], aabbs[G])
 
-                m_height[A] = 1 + MathUtils.max(m_height[B], m_height[F])
-                m_height[C] = 1 + MathUtils.max(m_height[A], m_height[G])
+                heights[A] = 1 + MathUtils.max(heights[B], heights[F])
+                heights[C] = 1 + MathUtils.max(heights[A], heights[G])
             }
 
-            return iC
+            return C
         }
 
         // Rotate B up
         if (balance < -1) {
-            val iD = m_child1[B]
-            val iE = m_child2[B]
-            val D = iD
-            val E = iE
-            assert(0 <= iD && iD < m_nodeCapacity)
-            assert(0 <= iE && iE < m_nodeCapacity)
+            val D = children1[B]
+            val E = children2[B]
+            assert(D in 0 until nodeCapacity)
+            assert(E in 0 until nodeCapacity)
 
             // Swap A and B
-            m_child1[B] = iA
-            m_parent[B] = m_parent[A]
-            val Bparent = m_parent[B]
-            m_parent[A] = iB
+            children1[B] = A
+            parents[B] = parents[A]
+            val Bparent = parents[B]
+            parents[A] = B
 
             // A's old parent should point to B
             if (Bparent != NULL_NODE) {
-                if (m_child1[Bparent] == iA) {
-                    m_child1[Bparent] = iB
+                if (children1[Bparent] == A) {
+                    children1[Bparent] = B
                 } else {
-                    assert(m_child2[Bparent] == iA)
-                    m_child2[Bparent] = iB
+                    assert(children2[Bparent] == A)
+                    children2[Bparent] = B
                 }
             } else {
-                m_root = iB
+                root = B
             }
 
             // Rotate
-            if (m_height[D] > m_height[E]) {
-                m_child2[B] = iD
-                m_child1[A] = iE
-                m_parent[E] = iA
-                m_aabb[A].combine(m_aabb[C], m_aabb[E])
-                m_aabb[B].combine(m_aabb[A], m_aabb[D])
+            if (heights[D] > heights[E]) {
+                children2[B] = D
+                children1[A] = E
+                parents[E] = A
+                aabbs[A].combine(aabbs[C], aabbs[E])
+                aabbs[B].combine(aabbs[A], aabbs[D])
 
-                m_height[A] = 1 + MathUtils.max(m_height[C], m_height[E])
-                m_height[B] = 1 + MathUtils.max(m_height[A], m_height[D])
+                heights[A] = 1 + MathUtils.max(heights[C], heights[E])
+                heights[B] = 1 + MathUtils.max(heights[A], heights[D])
             } else {
-                m_child2[B] = iE
-                m_child1[A] = iD
-                m_parent[D] = iA
-                m_aabb[A].combine(m_aabb[C], m_aabb[D])
-                m_aabb[B].combine(m_aabb[A], m_aabb[E])
+                children2[B] = E
+                children1[A] = D
+                parents[D] = A
+                aabbs[A].combine(aabbs[C], aabbs[D])
+                aabbs[B].combine(aabbs[A], aabbs[E])
 
-                m_height[A] = 1 + MathUtils.max(m_height[C], m_height[D])
-                m_height[B] = 1 + MathUtils.max(m_height[A], m_height[E])
+                heights[A] = 1 + MathUtils.max(heights[C], heights[D])
+                heights[B] = 1 + MathUtils.max(heights[A], heights[E])
             }
 
-            return iB
+            return B
         }
 
-        return iA
+        return A
     }
 
     private fun validateStructure(node: Int) {
-        if (node == NULL_NODE) {
-            return
+        if (node == NULL_NODE) return
+
+        if (node == root) {
+            assert(parents[node] == NULL_NODE)
         }
 
-        if (node == m_root) {
-            assert(m_parent[node] == NULL_NODE)
-        }
-
-        val child1 = m_child1[node]
-        val child2 = m_child2[node]
+        val child1 = children1[node]
+        val child2 = children2[node]
 
         if (child1 == NULL_NODE) {
             assert(child1 == NULL_NODE)
             assert(child2 == NULL_NODE)
-            assert(m_height[node] == 0)
+            assert(heights[node] == 0)
             return
         }
 
-        assert(child1 != NULL_NODE && 0 <= child1 && child1 < m_nodeCapacity)
-        assert(child2 != NULL_NODE && 0 <= child2 && child2 < m_nodeCapacity)
+        assert(child1 != NULL_NODE && child1 in 0 until nodeCapacity)
+        assert(child2 != NULL_NODE && child2 in 0 until nodeCapacity)
 
-        assert(m_parent[child1] == node)
-        assert(m_parent[child2] == node)
+        assert(parents[child1] == node)
+        assert(parents[child2] == node)
 
         validateStructure(child1)
         validateStructure(child2)
     }
 
     private fun validateMetrics(node: Int) {
-        if (node == NULL_NODE) {
-            return
-        }
+        if (node == NULL_NODE) return
 
-        val child1 = m_child1[node]
-        val child2 = m_child2[node]
+        val child1 = children1[node]
+        val child2 = children2[node]
 
         if (child1 == NULL_NODE) {
             assert(child1 == NULL_NODE)
             assert(child2 == NULL_NODE)
-            assert(m_height[node] == 0)
+            assert(heights[node] == 0)
             return
         }
 
-        assert(child1 != NULL_NODE && 0 <= child1 && child1 < m_nodeCapacity)
-        assert(child2 != child1 && 0 <= child2 && child2 < m_nodeCapacity)
+        assert(child1 != NULL_NODE && child1 in 0 until nodeCapacity)
+        assert(child2 != child1 && child2 in 0 until nodeCapacity)
 
-        val height1 = m_height[child1]
-        val height2 = m_height[child2]
-        val height: Int
-        height = 1 + MathUtils.max(height1, height2)
-        assert(m_height[node] == height)
+        val height1 = heights[child1]
+        val height2 = heights[child2]
+        val height = 1 + MathUtils.max(height1, height2)
+        assert(heights[node] == height)
 
         val aabb = AABB()
-        aabb.combine(m_aabb[child1], m_aabb[child2])
+        aabb.combine(aabbs[child1], aabbs[child2])
 
-        assert(aabb.lowerBound == m_aabb[node].lowerBound)
-        assert(aabb.upperBound == m_aabb[node].upperBound)
+        assert(aabb.lowerBound == aabbs[node].lowerBound)
+        assert(aabb.upperBound == aabbs[node].upperBound)
 
         validateMetrics(child1)
         validateMetrics(child2)
     }
 
     override fun drawTree(argDraw: DebugDraw) {
-        if (m_root == NULL_NODE) {
-            return
-        }
+        if (root == NULL_NODE) return
         val height = computeHeight()
-        drawTree(argDraw, m_root, 0, height)
+        drawTree(argDraw, root, 0, height)
     }
 
     fun drawTree(argDraw: DebugDraw, node: Int, spot: Int, height: Int) {
-        val a = m_aabb[node]
+        val a = aabbs[node]
         a.getVertices(drawVecs)
 
         color.set(1f, (height - spot) * 1f / height, (height - spot) * 1f / height)
@@ -853,8 +792,8 @@ class DynamicTreeFlatNodes : BroadPhaseStrategy {
         argDraw.viewportTranform!!.getWorldToScreen(a.upperBound, textVec)
         argDraw.drawString(textVec.x, textVec.y, node.toString() + "-" + (spot + 1) + "/" + height, color)
 
-        val c1 = m_child1[node]
-        val c2 = m_child2[node]
+        val c1 = children1[node]
+        val c2 = children2[node]
         if (c1 != NULL_NODE) {
             drawTree(argDraw, c1, spot + 1, height)
         }
@@ -864,11 +803,8 @@ class DynamicTreeFlatNodes : BroadPhaseStrategy {
     }
 
     companion object {
-
         val MAX_STACK_SIZE = 64
-
         val NULL_NODE = -1
-
         val INITIAL_BUFFER_LENGTH = 16
     }
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/broadphase/DynamicTreeNode.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/broadphase/DynamicTreeNode.kt
@@ -27,20 +27,16 @@ import org.jbox2d.collision.*
 import org.jbox2d.userdata.*
 
 class DynamicTreeNode(internal val id: Int) : Box2dTypedUserData by Box2dTypedUserData.Mixin() {
+
     /**
      * Enlarged AABB
      */
-
     val aabb = AABB()
-
 
     var userData: Any? = Unit
 
-
     internal var parent: DynamicTreeNode? = null
-
     internal var child1: DynamicTreeNode? = null
-
     internal var child2: DynamicTreeNode? = null
 
     internal var height: Int = 0

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/shapes/ChainShape.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/shapes/ChainShape.kt
@@ -23,7 +23,6 @@
  */
 package org.jbox2d.collision.shapes
 
-
 import org.jbox2d.collision.AABB
 import org.jbox2d.collision.RayCastInput
 import org.jbox2d.collision.RayCastOutput
@@ -36,77 +35,72 @@ import org.jbox2d.internal.*
 /**
  * A chain shape is a free form sequence of line segments. The chain has two-sided collision, so you
  * can use inside and outside collision. Therefore, you may use any winding order. Connectivity
- * information is used to create smooth collisions. WARNING: The chain will not collide properly if
- * there are self-intersections.
+ * information is used to create smooth collisions.
+ * WARNING: The chain will not collide properly if there are self-intersections.
  *
  * @author Daniel
  */
 class ChainShape : Shape(ShapeType.CHAIN) {
 
+    var vertices: Array<Vec2>? = null
 
-    var m_vertices: Array<Vec2>? = null
+    var count: Int = 0
 
-    var m_count: Int = 0
+    val prevVertex = Vec2()
+    val nextVertex = Vec2()
 
-    val m_prevVertex = Vec2()
-
-    val m_nextVertex = Vec2()
-
-    var m_hasPrevVertex = false
-
-    var m_hasNextVertex = false
+    var hasPrevVertex = false
+    var hasNextVertex = false
 
     private val pool0 = EdgeShape()
 
     init {
-        m_vertices = null
-        m_radius = Settings.polygonRadius
-        m_count = 0
+        radius = Settings.polygonRadius
     }
 
     fun clear() {
-        m_vertices = null
-        m_count = 0
+        vertices = null
+        count = 0
     }
 
     override fun getChildCount(): Int {
-        return m_count - 1
+        return count - 1
     }
 
     /**
      * Get a child edge.
      */
     fun getChildEdge(edge: EdgeShape, index: Int) {
-        assert(0 <= index && index < m_count - 1)
-        edge.m_radius = m_radius
+        assert(index in 0 until (count - 1))
+        edge.radius = radius
 
-        val v0 = m_vertices!![index + 0]
-        val v1 = m_vertices!![index + 1]
-        edge.m_vertex1.x = v0.x
-        edge.m_vertex1.y = v0.y
-        edge.m_vertex2.x = v1.x
-        edge.m_vertex2.y = v1.y
+        val v0 = vertices!![index + 0]
+        val v1 = vertices!![index + 1]
+        edge.vertex1.x = v0.x
+        edge.vertex1.y = v0.y
+        edge.vertex2.x = v1.x
+        edge.vertex2.y = v1.y
 
         if (index > 0) {
-            val v = m_vertices!![index - 1]
-            edge.m_vertex0.x = v.x
-            edge.m_vertex0.y = v.y
-            edge.m_hasVertex0 = true
+            val v = vertices!![index - 1]
+            edge.vertex0.x = v.x
+            edge.vertex0.y = v.y
+            edge.hasVertex0 = true
         } else {
-            edge.m_vertex0.x = m_prevVertex.x
-            edge.m_vertex0.y = m_prevVertex.y
-            edge.m_hasVertex0 = m_hasPrevVertex
+            edge.vertex0.x = prevVertex.x
+            edge.vertex0.y = prevVertex.y
+            edge.hasVertex0 = hasPrevVertex
         }
 
-        if (index < m_count - 2) {
-            val v = m_vertices!![index + 2]
-            edge.m_vertex3.x = v.x
-            edge.m_vertex3.y = v.y
-            edge.m_hasVertex3 = true
+        if (index < count - 2) {
+            val v = vertices!![index + 2]
+            edge.vertex3.x = v.x
+            edge.vertex3.y = v.y
+            edge.hasVertex3 = true
         } else {
-            edge.m_vertex3.x = m_nextVertex.x
-            edge.m_vertex3.y = m_nextVertex.y
-            edge.m_hasVertex3 = m_hasNextVertex
+            edge.vertex3.x = nextVertex.x
+            edge.vertex3.y = nextVertex.y
+            edge.hasVertex3 = hasNextVertex
         }
     }
 
@@ -121,38 +115,38 @@ class ChainShape : Shape(ShapeType.CHAIN) {
     }
 
     override fun raycast(output: RayCastOutput, input: RayCastInput, xf: Transform, childIndex: Int): Boolean {
-        assert(childIndex < m_count)
+        assert(childIndex < count)
 
         val edgeShape = pool0
 
         val i1 = childIndex
         var i2 = childIndex + 1
-        if (i2 == m_count) {
+        if (i2 == count) {
             i2 = 0
         }
-        val v = m_vertices!![i1]
-        edgeShape.m_vertex1.x = v.x
-        edgeShape.m_vertex1.y = v.y
-        val v1 = m_vertices!![i2]
-        edgeShape.m_vertex2.x = v1.x
-        edgeShape.m_vertex2.y = v1.y
+        val v = vertices!![i1]
+        edgeShape.vertex1.x = v.x
+        edgeShape.vertex1.y = v.y
+        val v1 = vertices!![i2]
+        edgeShape.vertex2.x = v1.x
+        edgeShape.vertex2.y = v1.y
 
         return edgeShape.raycast(output, input, xf, 0)
     }
 
     override fun computeAABB(aabb: AABB, xf: Transform, childIndex: Int) {
-        assert(childIndex < m_count)
+        assert(childIndex < count)
         val lower = aabb.lowerBound
         val upper = aabb.upperBound
 
         val i1 = childIndex
         var i2 = childIndex + 1
-        if (i2 == m_count) {
+        if (i2 == count) {
             i2 = 0
         }
 
-        val vi1 = m_vertices!![i1]
-        val vi2 = m_vertices!![i2]
+        val vi1 = vertices!![i1]
+        val vi2 = vertices!![i2]
         val xfq = xf.q
         val xfp = xf.p
         val v1x = xfq.c * vi1.x - xfq.s * vi1.y + xfp.x
@@ -174,11 +168,11 @@ class ChainShape : Shape(ShapeType.CHAIN) {
 
     override fun clone(): Shape {
         val clone = ChainShape()
-        clone.createChain(m_vertices, m_count)
-        clone.m_prevVertex.set(m_prevVertex)
-        clone.m_nextVertex.set(m_nextVertex)
-        clone.m_hasPrevVertex = m_hasPrevVertex
-        clone.m_hasNextVertex = m_hasNextVertex
+        clone.createChain(vertices, count)
+        clone.prevVertex.set(prevVertex)
+        clone.nextVertex.set(nextVertex)
+        clone.hasPrevVertex = hasPrevVertex
+        clone.hasNextVertex = hasNextVertex
         return clone
     }
 
@@ -189,10 +183,10 @@ class ChainShape : Shape(ShapeType.CHAIN) {
      * @param count the vertex count
      */
     fun createLoop(vertices: Array<Vec2>, count: Int) {
-        assert(m_vertices == null && m_count == 0)
+        assert(this.vertices == null && this.count == 0)
         assert(count >= 3)
-        m_count = count + 1
-        m_vertices = Array(m_count) { Vec2.dummy }
+        this.count = count + 1
+        this.vertices = Array(this.count) { Vec2.dummy }
         for (i in 1 until count) {
             val v1 = vertices[i - 1]
             val v2 = vertices[i]
@@ -202,13 +196,13 @@ class ChainShape : Shape(ShapeType.CHAIN) {
             }
         }
         for (i in 0 until count) {
-            m_vertices!![i] = Vec2(vertices[i])
+            this.vertices!![i] = Vec2(vertices[i])
         }
-        m_vertices!![count] = Vec2(m_vertices!![0])
-        m_prevVertex.set(m_vertices!![m_count - 2])
-        m_nextVertex.set(m_vertices!![1])
-        m_hasPrevVertex = true
-        m_hasNextVertex = true
+        this.vertices!![count] = Vec2(this.vertices!![0])
+        prevVertex.set(this.vertices!![this.count - 2])
+        nextVertex.set(this.vertices!![1])
+        hasPrevVertex = true
+        hasNextVertex = true
     }
 
     /**
@@ -218,11 +212,11 @@ class ChainShape : Shape(ShapeType.CHAIN) {
      * @param count the vertex count
      */
     fun createChain(vertices: Array<Vec2>?, count: Int) {
-        assert(m_vertices == null && m_count == 0)
+        assert(this.vertices == null && this.count == 0)
         assert(count >= 2)
-        m_count = count
-        m_vertices = Array(m_count) { Vec2.dummy }
-        for (i in 1 until m_count) {
+        this.count = count
+        this.vertices = Array(this.count) { Vec2.dummy }
+        for (i in 1 until this.count) {
             val v1 = vertices!![i - 1]
             val v2 = vertices[i]
             // If the code crashes here, it means your vertices are too close together.
@@ -230,33 +224,29 @@ class ChainShape : Shape(ShapeType.CHAIN) {
                 throw RuntimeException("Vertices of chain shape are too close together")
             }
         }
-        for (i in 0 until m_count) {
-            m_vertices!![i] = Vec2(vertices!![i])
+        for (i in 0 until this.count) {
+            this.vertices!![i] = Vec2(vertices!![i])
         }
-        m_hasPrevVertex = false
-        m_hasNextVertex = false
+        hasPrevVertex = false
+        hasNextVertex = false
 
-        m_prevVertex.setZero()
-        m_nextVertex.setZero()
+        prevVertex.setZero()
+        nextVertex.setZero()
     }
 
     /**
      * Establish connectivity to a vertex that precedes the first vertex. Don't call this for loops.
-     *
-     * @param prevVertex
      */
     fun setPrevVertex(prevVertex: Vec2) {
-        m_prevVertex.set(prevVertex)
-        m_hasPrevVertex = true
+        this.prevVertex.set(prevVertex)
+        hasPrevVertex = true
     }
 
     /**
      * Establish connectivity to a vertex that follows the last vertex. Don't call this for loops.
-     *
-     * @param nextVertex
      */
     fun setNextVertex(nextVertex: Vec2) {
-        m_nextVertex.set(nextVertex)
-        m_hasNextVertex = true
+        this.nextVertex.set(nextVertex)
+        hasNextVertex = true
     }
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/shapes/CircleShape.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/shapes/CircleShape.kt
@@ -36,55 +36,42 @@ import org.jbox2d.internal.*
 /**
  * A circle shape.
  */
-class CircleShape : Shape(ShapeType.CIRCLE) {
-    companion object {
-        operator fun invoke(radius: Number): CircleShape = CircleShape().also { it.m_radius = radius.toFloat() }
+class CircleShape() : Shape(ShapeType.CIRCLE) {
+
+    constructor(radius: Number) : this() {
+        this.radius = radius.toFloat()
     }
 
-    val m_p: Vec2 = Vec2()
+    val p: Vec2 = Vec2()
 
-    /**
-     * Get the vertex count.
-     *
-     * @return
-     */
-    val vertexCount: Int get() = 1
+    val vertexCount = 1
 
     override fun clone(): Shape {
         val shape = CircleShape()
-        shape.m_p.x = m_p.x
-        shape.m_p.y = m_p.y
-        shape.m_radius = m_radius
+        shape.p.x = p.x
+        shape.p.y = p.y
+        shape.radius = radius
         return shape
     }
 
     override fun getChildCount(): Int = 1
 
     /**
-     * Get the supporting vertex index in the given direction.
-     *
-     * @param d
-     * @return
+     * Get the supporting vertex index in the given direction [d].
      */
     fun getSupport(d: Vec2): Int = 0
 
     /**
-     * Get the supporting vertex in the given direction.
-     *
-     * @param d
-     * @return
+     * Get the supporting vertex in the given direction [d].
      */
-    fun getSupportVertex(d: Vec2): Vec2 = m_p
+    fun getSupportVertex(d: Vec2): Vec2 = p
 
     /**
-     * Get a vertex by index.
-     *
-     * @param index
-     * @return
+     * Get a vertex by [index].
      */
     fun getVertex(index: Int): Vec2 {
         assert(index == 0)
-        return m_p
+        return p
     }
 
     override fun testPoint(transform: Transform, p: Vec2): Boolean {
@@ -95,22 +82,22 @@ class CircleShape : Shape(ShapeType.CIRCLE) {
         // return Vec2.dot(d, d) <= m_radius * m_radius;
         val q = transform.q
         val tp = transform.p
-        val centerx = -(q.c * m_p.x - q.s * m_p.y + tp.x - p.x)
-        val centery = -(q.s * m_p.x + q.c * m_p.y + tp.y - p.y)
+        val centerx = -(q.c * this.p.x - q.s * this.p.y + tp.x - p.x)
+        val centery = -(q.s * this.p.x + q.c * this.p.y + tp.y - p.y)
 
-        return centerx * centerx + centery * centery <= m_radius * m_radius
+        return centerx * centerx + centery * centery <= radius * radius
     }
 
     override fun computeDistanceToOut(xf: Transform, p: Vec2, childIndex: Int, normalOut: Vec2): Float {
         val xfq = xf.q
-        val centerx = xfq.c * m_p.x - xfq.s * m_p.y + xf.p.x
-        val centery = xfq.s * m_p.x + xfq.c * m_p.y + xf.p.y
+        val centerx = xfq.c * this.p.x - xfq.s * this.p.y + xf.p.x
+        val centery = xfq.s * this.p.x + xfq.c * this.p.y + xf.p.y
         val dx = p.x - centerx
         val dy = p.y - centery
         val d1 = MathUtils.sqrt(dx * dx + dy * dy)
         normalOut.x = dx * 1 / d1
         normalOut.y = dy * 1 / d1
-        return d1 - m_radius
+        return d1 - radius
     }
 
     // Collision Detection in Interactive 3D Environments by Gino van den Bergen
@@ -118,8 +105,10 @@ class CircleShape : Shape(ShapeType.CIRCLE) {
     // x = s + a * r
     // norm(x) = radius
     override fun raycast(
-        output: RayCastOutput, input: RayCastInput,
-        transform: Transform, childIndex: Int
+        output: RayCastOutput,
+        input: RayCastInput,
+        transform: Transform,
+        childIndex: Int
     ): Boolean {
 
         val inputp1 = input.p1
@@ -129,13 +118,13 @@ class CircleShape : Shape(ShapeType.CIRCLE) {
 
         // Rot.mulToOutUnsafe(transform.q, m_p, position);
         // position.addLocal(transform.p);
-        val positionx = tq.c * m_p.x - tq.s * m_p.y + tp.x
-        val positiony = tq.s * m_p.x + tq.c * m_p.y + tp.y
+        val positionx = tq.c * p.x - tq.s * p.y + tp.x
+        val positiony = tq.s * p.x + tq.c * p.y + tp.y
 
         val sx = inputp1.x - positionx
         val sy = inputp1.y - positiony
         // final float b = Vec2.dot(s, s) - m_radius * m_radius;
-        val b = sx * sx + sy * sy - m_radius * m_radius
+        val b = sx * sx + sy * sy - radius * radius
 
         // Solve quadratic equation.
         val rx = inputp2.x - inputp1.x
@@ -170,22 +159,22 @@ class CircleShape : Shape(ShapeType.CIRCLE) {
     override fun computeAABB(aabb: AABB, transform: Transform, childIndex: Int) {
         val tq = transform.q
         val tp = transform.p
-        val px = tq.c * m_p.x - tq.s * m_p.y + tp.x
-        val py = tq.s * m_p.x + tq.c * m_p.y + tp.y
+        val px = tq.c * p.x - tq.s * p.y + tp.x
+        val py = tq.s * p.x + tq.c * p.y + tp.y
 
-        aabb.lowerBound.x = px - m_radius
-        aabb.lowerBound.y = py - m_radius
-        aabb.upperBound.x = px + m_radius
-        aabb.upperBound.y = py + m_radius
+        aabb.lowerBound.x = px - radius
+        aabb.lowerBound.y = py - radius
+        aabb.upperBound.x = px + radius
+        aabb.upperBound.y = py + radius
     }
 
     override fun computeMass(massData: MassData, density: Float) {
-        massData.mass = density * Settings.PI * m_radius * m_radius
-        massData.center.x = m_p.x
-        massData.center.y = m_p.y
+        massData.mass = density * Settings.PI * radius * radius
+        massData.center.x = p.x
+        massData.center.y = p.y
 
         // inertia about the local origin
         // massData.I = massData.mass * (0.5f * m_radius * m_radius + Vec2.dot(m_p, m_p));
-        massData.I = massData.mass * (0.5f * m_radius * m_radius + (m_p.x * m_p.x + m_p.y * m_p.y))
+        massData.I = massData.mass * (0.5f * radius * radius + (p.x * p.x + p.y * p.y))
     }
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/shapes/EdgeShape.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/shapes/EdgeShape.kt
@@ -39,48 +39,33 @@ import org.jbox2d.common.Vec2
  */
 class EdgeShape : Shape(ShapeType.EDGE) {
 
-    /**
-     * edge vertex 1
-     */
+    /** edge vertex 1 */
+    val vertex1 = Vec2()
+    /** edge vertex 2 */
+    val vertex2 = Vec2()
 
-    val m_vertex1 = Vec2()
-    /**
-     * edge vertex 2
-     */
+    /** optional adjacent vertex 1. Used for smooth collision */
+    val vertex0 = Vec2()
+    /** optional adjacent vertex 2. Used for smooth collision */
+    val vertex3 = Vec2()
 
-    val m_vertex2 = Vec2()
-
-    /**
-     * optional adjacent vertex 1. Used for smooth collision
-     */
-
-    val m_vertex0 = Vec2()
-    /**
-     * optional adjacent vertex 2. Used for smooth collision
-     */
-
-    val m_vertex3 = Vec2()
-
-    var m_hasVertex0 = false
-
-    var m_hasVertex3 = false
+    var hasVertex0 = false
+    var hasVertex3 = false
 
     // for pooling
     private val normal = Vec2()
 
     init {
-        m_radius = Settings.polygonRadius
+        radius = Settings.polygonRadius
     }
 
-    override fun getChildCount(): Int {
-        return 1
-    }
+    override fun getChildCount() = 1
 
     fun set(v1: Vec2, v2: Vec2) {
-        m_vertex1.set(v1)
-        m_vertex2.set(v2)
-        m_hasVertex3 = false
-        m_hasVertex0 = m_hasVertex3
+        vertex1.set(v1)
+        vertex2.set(v2)
+        hasVertex3 = false
+        hasVertex0 = hasVertex3
     }
 
     override fun testPoint(xf: Transform, p: Vec2): Boolean {
@@ -92,10 +77,10 @@ class EdgeShape : Shape(ShapeType.EDGE) {
         val xfqs = xf.q.s
         val xfpx = xf.p.x
         val xfpy = xf.p.y
-        val v1x = xfqc * m_vertex1.x - xfqs * m_vertex1.y + xfpx
-        val v1y = xfqs * m_vertex1.x + xfqc * m_vertex1.y + xfpy
-        val v2x = xfqc * m_vertex2.x - xfqs * m_vertex2.y + xfpx
-        val v2y = xfqs * m_vertex2.x + xfqc * m_vertex2.y + xfpy
+        val v1x = xfqc * vertex1.x - xfqs * vertex1.y + xfpx
+        val v1y = xfqs * vertex1.x + xfqc * vertex1.y + xfpy
+        val v2x = xfqc * vertex2.x - xfqs * vertex2.y + xfpx
+        val v2y = xfqs * vertex2.x + xfqc * vertex2.y + xfpy
 
         var dx = p.x - v1x
         var dy = p.y - v1y
@@ -132,8 +117,8 @@ class EdgeShape : Shape(ShapeType.EDGE) {
 
         var tempx: Float
         var tempy: Float
-        val v1 = m_vertex1
-        val v2 = m_vertex2
+        val v1 = vertex1
+        val v2 = vertex2
         val xfq = xf.q
         val xfp = xf.p
 
@@ -169,14 +154,10 @@ class EdgeShape : Shape(ShapeType.EDGE) {
         val numerator = normalx * tempx + normaly * tempy
         val denominator = normalx * dx + normaly * dy
 
-        if (denominator == 0.0f) {
-            return false
-        }
+        if (denominator == 0.0f) return false
 
         val t = numerator / denominator
-        if (t < 0.0f || 1.0f < t) {
-            return false
-        }
+        if (t < 0.0f || 1.0f < t) return false
 
         // Vec2 q = p1 + t * d;
         val qx = p1x + t * dx
@@ -188,16 +169,13 @@ class EdgeShape : Shape(ShapeType.EDGE) {
         val rx = v2.x - v1.x
         val ry = v2.y - v1.y
         val rr = rx * rx + ry * ry
-        if (rr == 0.0f) {
-            return false
-        }
+        if (rr == 0.0f) return false
+
         tempx = qx - v1.x
         tempy = qy - v1.y
         // float s = Vec2.dot(pool5, r) / rr;
         val s = (tempx * rx + tempy * ry) / rr
-        if (s < 0.0f || 1.0f < s) {
-            return false
-        }
+        if (s < 0.0f || 1.0f < s) return false
 
         output.fraction = t
         if (numerator > 0.0f) {
@@ -217,37 +195,37 @@ class EdgeShape : Shape(ShapeType.EDGE) {
         val upperBound = aabb.upperBound
         val xfq = xf.q
 
-        val v1x = xfq.c * m_vertex1.x - xfq.s * m_vertex1.y + xf.p.x
-        val v1y = xfq.s * m_vertex1.x + xfq.c * m_vertex1.y + xf.p.y
-        val v2x = xfq.c * m_vertex2.x - xfq.s * m_vertex2.y + xf.p.x
-        val v2y = xfq.s * m_vertex2.x + xfq.c * m_vertex2.y + xf.p.y
+        val v1x = xfq.c * vertex1.x - xfq.s * vertex1.y + xf.p.x
+        val v1y = xfq.s * vertex1.x + xfq.c * vertex1.y + xf.p.y
+        val v2x = xfq.c * vertex2.x - xfq.s * vertex2.y + xf.p.x
+        val v2y = xfq.s * vertex2.x + xfq.c * vertex2.y + xf.p.y
 
         lowerBound.x = if (v1x < v2x) v1x else v2x
         lowerBound.y = if (v1y < v2y) v1y else v2y
         upperBound.x = if (v1x > v2x) v1x else v2x
         upperBound.y = if (v1y > v2y) v1y else v2y
 
-        lowerBound.x -= m_radius
-        lowerBound.y -= m_radius
-        upperBound.x += m_radius
-        upperBound.y += m_radius
+        lowerBound.x -= radius
+        lowerBound.y -= radius
+        upperBound.x += radius
+        upperBound.y += radius
     }
 
     override fun computeMass(massData: MassData, density: Float) {
         massData.mass = 0.0f
-        massData.center.set(m_vertex1).addLocal(m_vertex2).mulLocal(0.5f)
+        massData.center.set(vertex1).addLocal(vertex2).mulLocal(0.5f)
         massData.I = 0.0f
     }
 
     override fun clone(): Shape {
         val edge = EdgeShape()
-        edge.m_radius = this.m_radius
-        edge.m_hasVertex0 = this.m_hasVertex0
-        edge.m_hasVertex3 = this.m_hasVertex3
-        edge.m_vertex0.set(this.m_vertex0)
-        edge.m_vertex1.set(this.m_vertex1)
-        edge.m_vertex2.set(this.m_vertex2)
-        edge.m_vertex3.set(this.m_vertex3)
+        edge.radius = this.radius
+        edge.hasVertex0 = this.hasVertex0
+        edge.hasVertex3 = this.hasVertex3
+        edge.vertex0.set(this.vertex0)
+        edge.vertex1.set(this.vertex1)
+        edge.vertex2.set(this.vertex2)
+        edge.vertex3.set(this.vertex3)
         return edge
     }
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/shapes/MassData.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/shapes/MassData.kt
@@ -48,18 +48,17 @@ package org.jbox2d.collision.shapes
 
 import org.jbox2d.common.Vec2
 
-// Updated to rev 100
-
 /** This holds the mass data computed for a shape.  */
 class MassData {
+
     /** The mass of the shape, usually in kilograms.  */
-    var mass: Float = 0.toFloat()
+    var mass: Float = 0f
+
     /** The position of the shape's centroid relative to the shape's origin.  */
-
     val center: Vec2
-    /** The rotational inertia of the shape about the local origin.  */
 
-    var I: Float = 0.toFloat()
+    /** The rotational inertia of the shape about the local origin.  */
+    var I: Float = 0f
 
     /**
      * Blank mass data
@@ -71,10 +70,7 @@ class MassData {
     }
 
     /**
-     * Copies from the given mass data
-     *
-     * @param md
-     * mass data to copy from
+     * Copies from the given mass data [md]
      */
     constructor(md: MassData) {
         mass = md.mass

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/shapes/Shape.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/shapes/Shape.kt
@@ -31,29 +31,19 @@ import org.jbox2d.common.Vec2
 
 /**
  * A shape is used for collision detection. You can create a shape however you like. Shapes used for
- * simulation in World are created automatically when a Fixture is created. Shapes may encapsulate a
+ * simulation in World are created automatically when a Fixture is created. Shapes may encapsulate
  * one or more child shapes.
  */
-abstract class Shape(private val m_type: ShapeType) {
+abstract class Shape(val type: ShapeType) {
+
     /**
      * The radius of the underlying shape. This can refer to different things depending on the shape
      * implementation
-     *
-     * @return
      */
-    var m_radius: Float = 0f
-
-    /**
-     * Get the type of this shape. You can use this to down cast to the concrete shape.
-     *
-     * @return the shape type.
-     */
-    fun getType(): ShapeType = m_type
+    var radius: Float = 0f
 
     /**
      * Get the number of child primitives
-     *
-     * @return
      */
     abstract fun getChildCount(): Int
 
@@ -68,21 +58,19 @@ abstract class Shape(private val m_type: ShapeType) {
     /**
      * Cast a ray against a child shape.
      *
-     * @param argOutput the ray-cast results.
-     * @param argInput the ray-cast input parameters.
-     * @param argTransform the transform to be applied to the shape.
-     * @param argChildIndex the child shape index
-     * @return if hit
+     * @param output the ray-cast results.
+     * @param input the ray-cast input parameters.
+     * @param transform the transform to be applied to the shape.
+     * @param childIndex the child shape index
+     * @return true if hit
      */
-    abstract fun raycast(output: RayCastOutput, input: RayCastInput, transform: Transform,
-                         childIndex: Int): Boolean
-
+    abstract fun raycast(output: RayCastOutput, input: RayCastInput, transform: Transform, childIndex: Int): Boolean
 
     /**
      * Given a transform, compute the associated axis aligned bounding box for a child shape.
      *
-     * @param argAabb returns the axis aligned box.
-     * @param argXf the world transform of the shape.
+     * @param aabb returns the axis aligned box.
+     * @param xf the world transform of the shape.
      */
     abstract fun computeAABB(aabb: AABB, xf: Transform, childIndex: Int)
 
@@ -102,7 +90,7 @@ abstract class Shape(private val m_type: ShapeType) {
      * @param xf the shape world transform.
      * @param p a point in world coordinates.
      * @param normalOut returns the direction in which the distance increases.
-     * @return distance returns the distance from the current shape.
+     * @return the distance from the current shape.
      */
     abstract fun computeDistanceToOut(xf: Transform, p: Vec2, childIndex: Int, normalOut: Vec2): Float
 

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/common/BufferUtils.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/common/BufferUtils.kt
@@ -3,18 +3,17 @@ package org.jbox2d.common
 import org.jbox2d.internal.*
 
 object BufferUtils {
-    /** Reallocate a buffer.  */
 
+    /** Reallocate a buffer. */
     fun <T : Any> reallocateBuffer(
-        klass: () -> T, oldBuffer: Array<T>?, oldCapacity: Int,
-        newCapacity: Int
+        generate: () -> T, oldBuffer: Array<T>?,
+        oldCapacity: Int, newCapacity: Int
     ): Array<T> {
         assert(newCapacity > oldCapacity)
-        return Array<Any>(newCapacity) { if (oldBuffer != null && it < oldCapacity) oldBuffer[it] else klass() } as Array<T>
+        return Array<Any>(newCapacity) { if (oldBuffer != null && it < oldCapacity) oldBuffer[it] else generate() } as Array<T>
     }
 
-    /** Reallocate a buffer.  */
-
+    /** Reallocate a buffer. */
     fun reallocateBuffer(oldBuffer: IntArray?, oldCapacity: Int, newCapacity: Int): IntArray {
         assert(newCapacity > oldCapacity)
         val newBuffer = IntArray(newCapacity)
@@ -24,8 +23,7 @@ object BufferUtils {
         return newBuffer
     }
 
-    /** Reallocate a buffer.  */
-
+    /** Reallocate a buffer. */
     fun reallocateBuffer(oldBuffer: FloatArray?, oldCapacity: Int, newCapacity: Int): FloatArray {
         assert(newCapacity > oldCapacity)
         val newBuffer = FloatArray(newCapacity)
@@ -39,7 +37,6 @@ object BufferUtils {
      * Reallocate a buffer. A 'deferred' buffer is reallocated only if it is not NULL. If
      * 'userSuppliedCapacity' is not zero, buffer is user supplied and must be kept.
      */
-
     fun <T : Any> reallocateBuffer(
         klass: () -> T, buffer: Array<T>?, userSuppliedCapacity: Int,
         oldCapacity: Int, newCapacity: Int, deferred: Boolean
@@ -57,10 +54,9 @@ object BufferUtils {
      * Reallocate an int buffer. A 'deferred' buffer is reallocated only if it is not NULL. If
      * 'userSuppliedCapacity' is not zero, buffer is user supplied and must be kept.
      */
-
     fun reallocateBuffer(
-        buffer: IntArray?, userSuppliedCapacity: Int, oldCapacity: Int,
-        newCapacity: Int, deferred: Boolean
+        buffer: IntArray?, userSuppliedCapacity: Int,
+        oldCapacity: Int, newCapacity: Int, deferred: Boolean
     ): IntArray {
         var buffer = buffer
         assert(newCapacity > oldCapacity)
@@ -75,10 +71,9 @@ object BufferUtils {
      * Reallocate a float buffer. A 'deferred' buffer is reallocated only if it is not NULL. If
      * 'userSuppliedCapacity' is not zero, buffer is user supplied and must be kept.
      */
-
     fun reallocateBuffer(
-        buffer: FloatArray?, userSuppliedCapacity: Int, oldCapacity: Int,
-        newCapacity: Int, deferred: Boolean
+        buffer: FloatArray?, userSuppliedCapacity: Int,
+        oldCapacity: Int, newCapacity: Int, deferred: Boolean
     ): FloatArray {
         var buffer = buffer
         assert(newCapacity > oldCapacity)
@@ -90,11 +85,10 @@ object BufferUtils {
     }
 
     /** Rotate an array, see std::rotate  */
-
     fun <T> rotate(ray: Array<T>, first: Int, new_first: Int, last: Int) {
         var first = first
-        var new_first = new_first
-        var next = new_first
+        var newFirst = new_first
+        var next = newFirst
         while (next != first) {
             val temp = ray[first]
             ray[first] = ray[next]
@@ -102,19 +96,18 @@ object BufferUtils {
             first++
             next++
             if (next == last) {
-                next = new_first
-            } else if (first == new_first) {
-                new_first = next
+                next = newFirst
+            } else if (first == newFirst) {
+                newFirst = next
             }
         }
     }
 
     /** Rotate an array, see std::rotate  */
-
     fun rotate(ray: IntArray, first: Int, new_first: Int, last: Int) {
         var first = first
-        var new_first = new_first
-        var next = new_first
+        var newFirst = new_first
+        var next = newFirst
         while (next != first) {
             val temp = ray[first]
             ray[first] = ray[next]
@@ -122,19 +115,18 @@ object BufferUtils {
             first++
             next++
             if (next == last) {
-                next = new_first
-            } else if (first == new_first) {
-                new_first = next
+                next = newFirst
+            } else if (first == newFirst) {
+                newFirst = next
             }
         }
     }
 
     /** Rotate an array, see std::rotate  */
-
     fun rotate(ray: FloatArray, first: Int, new_first: Int, last: Int) {
         var first = first
-        var new_first = new_first
-        var next = new_first
+        var newFirst = new_first
+        var next = newFirst
         while (next != first) {
             val temp = ray[first]
             ray[first] = ray[next]
@@ -142,9 +134,9 @@ object BufferUtils {
             first++
             next++
             if (next == last) {
-                next = new_first
-            } else if (first == new_first) {
-                new_first = next
+                next = newFirst
+            } else if (first == newFirst) {
+                newFirst = next
             }
         }
     }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/common/Color3f.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/common/Color3f.kt
@@ -43,31 +43,24 @@
  * misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  */
-
 package org.jbox2d.common
 
-import org.jbox2d.internal.*
 import kotlin.native.concurrent.ThreadLocal
 
-// updated to rev 100
 /**
  * Similar to javax.vecmath.Color3f holder
  * @author ewjordan
  */
 class Color3f {
 
-
-    var x: Float = 0.toFloat()
-
-    var y: Float = 0.toFloat()
-
-    var z: Float = 0.toFloat()
-
+    var x: Float = 0f
+    var y: Float = 0f
+    var z: Float = 0f
 
     constructor() {
+        x = 0f
+        y = 0f
         z = 0f
-        y = z
-        x = y
     }
 
     constructor(r: Float, g: Float, b: Float) {
@@ -89,19 +82,14 @@ class Color3f {
     }
 
     companion object {
-
         @ThreadLocal
         val WHITE = Color3f(1f, 1f, 1f)
-
         @ThreadLocal
         val BLACK = Color3f(0f, 0f, 0f)
-
         @ThreadLocal
         val BLUE = Color3f(0f, 0f, 1f)
-
         @ThreadLocal
         val GREEN = Color3f(0f, 1f, 0f)
-
         @ThreadLocal
         val RED = Color3f(1f, 0f, 0f)
     }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/common/IViewportTransform.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/common/IViewportTransform.kt
@@ -32,10 +32,7 @@ package org.jbox2d.common
 interface IViewportTransform {
 
     /**
-     * @return if the transform flips the y axis
-     */
-    /**
-     * @param yFlip if we flip the y axis when transforming
+     * Whether the transform flips the y axis
      */
     var isYFlip: Boolean
 
@@ -43,17 +40,10 @@ interface IViewportTransform {
      * This is the half-width and half-height. This should be the actual half-width and half-height,
      * not anything transformed or scaled. Not a copy.
      */
-    /**
-     * This sets the half-width and half-height. This should be the actual half-width and half-height,
-     * not anything transformed or scaled.
-     */
     var extents: Vec2
 
     /**
-     * center of the viewport. Not a copy.
-     */
-    /**
-     * sets the center of the viewport.
+     * Center of the viewport. Not a copy.
      */
     var center: Vec2
 
@@ -66,7 +56,7 @@ interface IViewportTransform {
     fun setExtents(halfWidth: Float, halfHeight: Float)
 
     /**
-     * sets the center of the viewport.
+     * Sets the center of the viewport.
      */
     fun setCenter(x: Float, y: Float)
 
@@ -80,28 +70,25 @@ interface IViewportTransform {
      */
     fun getWorldVectorToScreen(world: Vec2, screen: Vec2)
 
-
     /**
      * Transforms the given directional screen vector back to the world direction.
      */
     fun getScreenVectorToWorld(screen: Vec2, world: Vec2)
 
-
     /**
-     * takes the world coordinate (world) puts the corresponding screen coordinate in screen. It
+     * Takes the [world] coordinates and puts the corresponding [screen] coordinates in screen. It
      * should be safe to give the same object as both parameters.
      */
     fun getWorldToScreen(world: Vec2, screen: Vec2)
 
-
     /**
-     * takes the screen coordinates (screen) and puts the corresponding world coordinates in world. It
+     * Takes the [screen] coordinates and puts the corresponding [world] coordinates in world. It
      * should be safe to give the same object as both parameters.
      */
     fun getScreenToWorld(screen: Vec2, world: Vec2)
 
     /**
-     * Multiplies the viewport transform by the given Mat22
+     * Multiplies the viewport transform by the given Mat22 [transform]
      */
     fun mulByTransform(transform: Mat22)
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/common/Mat22.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/common/Mat22.kt
@@ -27,47 +27,36 @@ import com.soywiz.korma.geom.*
 import org.jbox2d.internal.*
 
 /**
- * A 2-by-2 matrix. Stored in column-major order.
+ * A 2x2 matrix. Stored in column-major order.
  */
 class Mat22 {
 
-
     val ex: Vec2
-
     val ey: Vec2
 
     /**
      * Extract the angle in radians from this matrix (assumed to be a rotation matrix).
-     *
-     * @return
      */
     val angleRadians: Float get() = MathUtils.atan2(ex.y, ex.x)
 
     /**
      * Extract the angle in degrees from this matrix (assumed to be a rotation matrix).
-     *
-     * @return
      */
     val angleDegrees: Float get() = angleRadians * MathUtils.RAD2DEG
 
     /**
      * Extract the angle from this matrix (assumed to be a rotation matrix).
-     *
-     * @return
      */
     val angle: Angle get() = angleRadians.radians
 
     /** Convert the matrix to printable format.  */
     override fun toString(): String {
-        var s = ""
-        s += "[" + ex.x + "," + ey.x + "]\n"
-        s += "[" + ex.y + "," + ey.y + "]"
-        return s
+        return "[${ex.x},${ey.x}]\n[${ex.y},${ey.y}]"
     }
 
     /**
-     * Construct zero matrix. Note: this is NOT an identity matrix! djm fixed double allocation
-     * problem
+     * Construct zero matrix. Note: this is NOT an identity matrix!
+     * djm fixed double allocation problem
      */
     constructor() {
         ex = Vec2()
@@ -75,10 +64,7 @@ class Mat22 {
     }
 
     /**
-     * Create a matrix with given vectors as columns.
-     *
-     * @param c1 Column 1 of matrix
-     * @param c2 Column 2 of matrix
+     * Create a matrix with given vectors [c1] and [c2] as columns.
      */
     constructor(c1: Vec2, c2: Vec2) {
         ex = c1.clone()
@@ -87,21 +73,14 @@ class Mat22 {
 
     /**
      * Create a matrix from four floats.
-     *
-     * @param exx
-     * @param col2x
-     * @param exy
-     * @param col2y
      */
-    constructor(exx: Float, col2x: Float, exy: Float, col2y: Float) {
-        ex = Vec2(exx, exy)
+    constructor(col1x: Float, col2x: Float, col1y: Float, col2y: Float) {
+        ex = Vec2(col1x, col1y)
         ey = Vec2(col2x, col2y)
     }
 
     /**
-     * Set as a copy of another matrix.
-     *
-     * @param m Matrix to copy
+     * Set as a copy of another matrix [m].
      */
     fun set(m: Mat22): Mat22 {
         ex.x = m.ex.x
@@ -111,9 +90,9 @@ class Mat22 {
         return this
     }
 
-    fun set(exx: Float, col2x: Float, exy: Float, col2y: Float): Mat22 {
-        ex.x = exx
-        ex.y = exy
+    fun set(col1x: Float, col2x: Float, col1y: Float, col2y: Float): Mat22 {
+        ex.x = col1x
+        ex.y = col1y
         ey.x = col2x
         ey.y = col2y
         return this
@@ -122,15 +101,12 @@ class Mat22 {
     /**
      * Return a clone of this matrix. djm fixed double allocation
      */
-    // @Override // annotation omitted for GWT-compatibility
     fun clone(): Mat22 {
-        return Mat22(ex!!, ey!!)
+        return Mat22(ex, ey)
     }
 
     /**
-     * Set as a matrix representing a rotation.
-     *
-     * @param angleRadians Rotation (in radians) that matrix represents.
+     * Set as a matrix representing a rotation in radians ([angleRadians]).
      */
     fun setRadians(angleRadians: Float) {
         val c = MathUtils.cos(angleRadians)
@@ -166,10 +142,7 @@ class Mat22 {
     }
 
     /**
-     * Set by column vectors.
-     *
-     * @param c1 Column 1
-     * @param c2 Column 2
+     * Set by column vectors [c1] and [c2].
      */
     fun set(c1: Vec2, c2: Vec2) {
         ex.x = c1.x
@@ -178,7 +151,7 @@ class Mat22 {
         ey.y = c2.y
     }
 
-    /** Returns the inverted Mat22 - does NOT invert the matrix locally!  */
+    /** Returns a new inverted Mat22 - does NOT invert the matrix locally!  */
     fun invert(): Mat22 {
         val a = ex.x
         val b = ey.x
@@ -226,15 +199,11 @@ class Mat22 {
         out.ey.y = det * a
     }
 
-
     /**
      * Return the matrix composed of the absolute values of all elements. djm: fixed double allocation
-     *
-     * @return Absolute value matrix
      */
     fun abs(): Mat22 {
-        return Mat22(MathUtils.abs(ex.x), MathUtils.abs(ey.x), MathUtils.abs(ex.y),
-                MathUtils.abs(ey.y))
+        return Mat22(MathUtils.abs(ex.x), MathUtils.abs(ey.x), MathUtils.abs(ex.y), MathUtils.abs(ey.y))
     }
 
     /* djm: added */
@@ -244,10 +213,7 @@ class Mat22 {
     }
 
     /**
-     * Multiply a vector by this matrix.
-     *
-     * @param v Vector to multiply by matrix.
-     * @return Resulting vector
+     * Multiply a vector [v] by this matrix.
      */
     fun mul(v: Vec2): Vec2 {
         return Vec2(ex.x * v.x + ey.x * v.y, ex.y * v.x + ey.y * v.y)
@@ -265,23 +231,15 @@ class Mat22 {
         out.y = ex.y * v.x + ey.y * v.y
     }
 
-
     /**
      * Multiply another matrix by this one (this one on left). djm optimized
-     *
-     * @param R
-     * @return
      */
     fun mul(R: Mat22): Mat22 {
-        /*
-     * Mat22 C = new Mat22();C.set(this.mul(R.ex), this.mul(R.ey));return C;
-     */
         val C = Mat22()
         C.ex.x = ex.x * R.ex.x + ey.x * R.ex.y
         C.ex.y = ex.y * R.ex.x + ey.y * R.ex.y
         C.ey.x = ex.x * R.ey.x + ey.x * R.ey.y
         C.ey.y = ex.y * R.ey.x + ey.y * R.ey.y
-        // C.set(ex,col2);
         return C
     }
 
@@ -311,24 +269,14 @@ class Mat22 {
     }
 
     /**
-     * Multiply another matrix by the transpose of this one (transpose of this one on left). djm:
-     * optimized
-     *
-     * @param B
-     * @return
+     * Multiply another matrix [B] by the transpose of this one (transpose of this one on left).
+     * djm: optimized
      */
     fun mulTrans(B: Mat22): Mat22 {
-        /*
-     * Vec2 c1 = new Vec2(Vec2.dot(this.ex, B.ex), Vec2.dot(this.ey, B.ex)); Vec2 c2 = new
-     * Vec2(Vec2.dot(this.ex, B.ey), Vec2.dot(this.ey, B.ey)); Mat22 C = new Mat22(); C.set(c1, c2);
-     * return C;
-     */
         val C = Mat22()
-
-        C.ex.x = Vec2.dot(this.ex!!, B.ex!!)
-        C.ex.y = Vec2.dot(this.ey!!, B.ex)
-
-        C.ey.x = Vec2.dot(this.ex, B.ey!!)
+        C.ex.x = Vec2.dot(this.ex, B.ex)
+        C.ex.y = Vec2.dot(this.ey, B.ex)
+        C.ey.x = Vec2.dot(this.ex, B.ey)
         C.ey.y = Vec2.dot(this.ey, B.ey)
         return C
     }
@@ -339,10 +287,6 @@ class Mat22 {
     }
 
     fun mulTransToOut(B: Mat22, out: Mat22) {
-        /*
-     * out.ex.x = Vec2.dot(this.ex, B.ex); out.ex.y = Vec2.dot(this.ey, B.ex); out.ey.x =
-     * Vec2.dot(this.ex, B.ey); out.ey.y = Vec2.dot(this.ey, B.ey);
-     */
         val x1 = this.ex.x * B.ex.x + this.ex.y * B.ex.y
         val y1 = this.ey.x * B.ex.x + this.ey.y * B.ex.y
         val x2 = this.ex.x * B.ey.x + this.ex.y * B.ey.y
@@ -363,34 +307,23 @@ class Mat22 {
     }
 
     /**
-     * Multiply a vector by the transpose of this matrix.
-     *
-     * @param v
-     * @return
+     * Multiply a vector [v] by the transpose of this matrix.
      */
     fun mulTrans(v: Vec2): Vec2 {
-        // return new Vec2(Vec2.dot(v, ex), Vec2.dot(v, col2));
         return Vec2(v.x * ex.x + v.y * ex.y, v.x * ey.x + v.y * ey.y)
     }
 
     /* djm added */
     fun mulTransToOut(v: Vec2, out: Vec2) {
-        /*
-     * out.x = Vec2.dot(v, ex); out.y = Vec2.dot(v, col2);
-     */
         val tempx = v.x * ex.x + v.y * ex.y
         out.y = v.x * ey.x + v.y * ey.y
         out.x = tempx
     }
 
     /**
-     * Add this matrix to B, return the result.
-     *
-     * @param B
-     * @return
+     * Add this matrix to [B], return the result.
      */
     fun add(B: Mat22): Mat22 {
-        // return new Mat22(ex.add(B.ex), col2.add(B.ey));
         val m = Mat22()
         m.ex.x = ex.x + B.ex.x
         m.ex.y = ex.y + B.ex.y
@@ -400,14 +333,9 @@ class Mat22 {
     }
 
     /**
-     * Add B to this matrix locally.
-     *
-     * @param B
-     * @return
+     * Add [B] to this matrix locally.
      */
     fun addLocal(B: Mat22): Mat22 {
-        // ex.addLocal(B.ex);
-        // col2.addLocal(B.ey);
         ex.x += B.ex.x
         ex.y += B.ex.y
         ey.x += B.ey.x
@@ -455,33 +383,26 @@ class Mat22 {
         return result
     }
 
-    override fun equals(obj: Any?): Boolean {
-        if (this === obj) return true
-        if (obj == null) return false
-        if (this::class != obj::class) return false
-        val other = obj as Mat22?
-        if (ex == null) {
-            if (other?.ex != null) return false
-        } else if (ex != other?.ex) return false
-        if (ey == null) {
-            if (other?.ey != null) return false
-        } else if (ey != other?.ey) return false
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null) return false
+        if (this::class != other::class) return false
+        val oth = other as Mat22?
+        if (ex != oth?.ex) return false
+        if (ey != oth?.ey) return false
         return true
     }
 
     companion object {
+
         /**
          * Return the matrix composed of the absolute values of all elements.
-         *
-         * @return Absolute value matrix
          */
-
         fun abs(R: Mat22): Mat22 {
             return R.abs()
         }
 
         /* djm created */
-
         fun absToOut(R: Mat22, out: Mat22) {
             out.ex.x = MathUtils.abs(R.ex.x)
             out.ex.y = MathUtils.abs(R.ex.y)
@@ -489,12 +410,9 @@ class Mat22 {
             out.ey.y = MathUtils.abs(R.ey.y)
         }
 
-
         fun mul(R: Mat22, v: Vec2): Vec2 {
-            // return R.mul(v);
             return Vec2(R.ex.x * v.x + R.ey.x * v.y, R.ex.y * v.x + R.ey.y * v.y)
         }
-
 
         fun mulToOut(R: Mat22, v: Vec2, out: Vec2) {
             val tempy = R.ex.y * v.x + R.ey.y * v.y
@@ -502,16 +420,13 @@ class Mat22 {
             out.y = tempy
         }
 
-
         fun mulToOutUnsafe(R: Mat22, v: Vec2, out: Vec2) {
             assert(v !== out)
             out.x = R.ex.x * v.x + R.ey.x * v.y
             out.y = R.ex.y * v.x + R.ey.y * v.y
         }
 
-
         fun mul(A: Mat22, B: Mat22): Mat22 {
-            // return A.mul(B);
             val C = Mat22()
             C.ex.x = A.ex.x * B.ex.x + A.ey.x * B.ex.y
             C.ex.y = A.ex.y * B.ex.x + A.ey.y * B.ex.y
@@ -519,7 +434,6 @@ class Mat22 {
             C.ey.y = A.ex.y * B.ey.x + A.ey.y * B.ey.y
             return C
         }
-
 
         fun mulToOut(A: Mat22, B: Mat22, out: Mat22) {
             val tempy1 = A.ex.y * B.ex.x + A.ey.y * B.ex.y
@@ -532,7 +446,6 @@ class Mat22 {
             out.ey.y = tempy2
         }
 
-
         fun mulToOutUnsafe(A: Mat22, B: Mat22, out: Mat22) {
             assert(out !== A)
             assert(out !== B)
@@ -542,11 +455,9 @@ class Mat22 {
             out.ey.y = A.ex.y * B.ey.x + A.ey.y * B.ey.y
         }
 
-
         fun mulTrans(R: Mat22, v: Vec2): Vec2 {
             return Vec2(v.x * R.ex.x + v.y * R.ex.y, v.x * R.ey.x + v.y * R.ey.y)
         }
-
 
         fun mulTransToOut(R: Mat22, v: Vec2, out: Vec2) {
             val outx = v.x * R.ex.x + v.y * R.ex.y
@@ -554,13 +465,11 @@ class Mat22 {
             out.x = outx
         }
 
-
         fun mulTransToOutUnsafe(R: Mat22, v: Vec2, out: Vec2) {
             assert(out !== v)
             out.y = v.x * R.ey.x + v.y * R.ey.y
             out.x = v.x * R.ex.x + v.y * R.ex.y
         }
-
 
         fun mulTrans(A: Mat22, B: Mat22): Mat22 {
             val C = Mat22()
@@ -570,7 +479,6 @@ class Mat22 {
             C.ey.y = A.ey.x * B.ey.x + A.ey.y * B.ey.y
             return C
         }
-
 
         fun mulTransToOut(A: Mat22, B: Mat22, out: Mat22) {
             val x1 = A.ex.x * B.ex.x + A.ex.y * B.ex.y
@@ -584,7 +492,6 @@ class Mat22 {
             out.ey.y = y2
         }
 
-
         fun mulTransToOutUnsafe(A: Mat22, B: Mat22, out: Mat22) {
             assert(A !== out)
             assert(B !== out)
@@ -593,7 +500,6 @@ class Mat22 {
             out.ey.x = A.ex.x * B.ey.x + A.ex.y * B.ey.y
             out.ey.y = A.ey.x * B.ey.x + A.ey.y * B.ey.y
         }
-
 
         fun createRotationalTransformRadians(angleRadians: Float, out: Mat22 = Mat22()): Mat22 {
             val c = MathUtils.cos(angleRadians)
@@ -605,12 +511,11 @@ class Mat22 {
             return out
         }
 
-        fun createRotationalTransformDegrees(angleDegrees: Float, out: Mat22 = Mat22()): Mat22
-            = createRotationalTransformRadians(angleDegrees * MathUtils.DEG2RAD, out)
+        fun createRotationalTransformDegrees(angleDegrees: Float, out: Mat22 = Mat22()): Mat22 =
+            createRotationalTransformRadians(angleDegrees * MathUtils.DEG2RAD, out)
 
-        fun createRotationalTransform(angle: Angle, out: Mat22 = Mat22()): Mat22
-            = createRotationalTransformRadians(angle.radians.toFloat(), out)
-
+        fun createRotationalTransform(angle: Angle, out: Mat22 = Mat22()): Mat22 =
+            createRotationalTransformRadians(angle.radians.toFloat(), out)
 
         fun createScaleTransform(scale: Float): Mat22 {
             val mat = Mat22()
@@ -618,7 +523,6 @@ class Mat22 {
             mat.ey.y = scale
             return mat
         }
-
 
         fun createScaleTransform(scale: Float, out: Mat22) {
             out.ex.x = scale

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/common/Mat33.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/common/Mat33.kt
@@ -26,17 +26,14 @@ package org.jbox2d.common
 import org.jbox2d.internal.*
 
 /**
- * A 3-by-3 matrix. Stored in column-major order.
+ * A 3x3 matrix. Stored in column-major order.
  *
  * @author Daniel Murphy
  */
 class Mat33 {
 
-
     val ex: Vec3
-
     val ey: Vec3
-
     val ez: Vec3
 
     constructor() {
@@ -45,8 +42,11 @@ class Mat33 {
         ez = Vec3()
     }
 
-    constructor(exx: Float, exy: Float, exz: Float, eyx: Float, eyy: Float, eyz: Float, ezx: Float,
-                ezy: Float, ezz: Float) {
+    constructor(
+        exx: Float, exy: Float, exz: Float,
+        eyx: Float, eyy: Float, eyz: Float,
+        ezx: Float, ezy: Float, ezz: Float
+    ) {
         ex = Vec3(exx, exy, exz)
         ey = Vec3(eyx, eyy, eyz)
         ez = Vec3(ezx, ezy, ezz)
@@ -64,8 +64,11 @@ class Mat33 {
         ez.setZero()
     }
 
-    fun set(exx: Float, exy: Float, exz: Float, eyx: Float, eyy: Float, eyz: Float, ezx: Float,
-                     ezy: Float, ezz: Float) {
+    fun set(
+        exx: Float, exy: Float, exz: Float,
+        eyx: Float, eyy: Float, eyz: Float,
+        ezx: Float, ezy: Float, ezz: Float
+    ) {
         ex.x = exx
         ex.y = exy
         ex.z = exz
@@ -93,23 +96,20 @@ class Mat33 {
     }
 
     fun setIdentity() {
-        ex.x = 1.toFloat()
-        ex.y = 0.toFloat()
-        ex.z = 0.toFloat()
-        ey.x = 0.toFloat()
-        ey.y = 1.toFloat()
-        ey.z = 0.toFloat()
-        ez.x = 0.toFloat()
-        ez.y = 0.toFloat()
-        ez.z = 1.toFloat()
+        ex.x = 1f
+        ex.y = 0f
+        ex.z = 0f
+        ey.x = 0f
+        ey.y = 1f
+        ey.z = 0f
+        ez.x = 0f
+        ez.y = 0f
+        ez.z = 1f
     }
 
     /**
-     * Solve A * x = b, where b is a column vector. This is more efficient than computing the inverse
+     * Solve A * x = b, where [b] is a column vector. This is more efficient than computing the inverse
      * in one-shot cases.
-     *
-     * @param b
-     * @return
      */
     fun solve22(b: Vec2): Vec2 {
         val x = Vec2()
@@ -118,11 +118,8 @@ class Mat33 {
     }
 
     /**
-     * Solve A * x = b, where b is a column vector. This is more efficient than computing the inverse
+     * Solve A * x = b, where [b] is a column vector. This is more efficient than computing the inverse
      * in one-shot cases.
-     *
-     * @param b
-     * @return
      */
     fun solve22ToOut(b: Vec2, out: Vec2) {
         val a11 = ex.x
@@ -139,11 +136,8 @@ class Mat33 {
 
     // djm pooling from below
     /**
-     * Solve A * x = b, where b is a column vector. This is more efficient than computing the inverse
+     * Solve A * x = b, where [b] is a column vector. This is more efficient than computing the inverse
      * in one-shot cases.
-     *
-     * @param b
-     * @return
      */
     fun solve33(b: Vec3): Vec3 {
         val x = Vec3()
@@ -152,16 +146,13 @@ class Mat33 {
     }
 
     /**
-     * Solve A * x = b, where b is a column vector. This is more efficient than computing the inverse
+     * Solve A * x = b, where [b] is a column vector. This is more efficient than computing the inverse
      * in one-shot cases.
-     *
-     * @param b
-     * @param out the result
      */
     fun solve33ToOut(b: Vec3, out: Vec3) {
         assert(b !== out)
-        Vec3.crossToOutUnsafe(ey!!, ez!!, out)
-        var det = Vec3.dot(ex!!, out)
+        Vec3.crossToOutUnsafe(ey, ez, out)
+        var det = Vec3.dot(ex, out)
         if (det != 0.0f) {
             det = 1.0f / det
         }
@@ -197,7 +188,9 @@ class Mat33 {
         M.ez.z = 0.0f
     }
 
-    // / Returns the zero matrix if singular.
+    /**
+     * Returns the zero matrix if singular.
+     */
     fun getSymInverse33(M: Mat33) {
         val bx = ey.y * ez.z - ey.z * ez.y
         val by = ey.z * ez.x - ey.x * ez.z
@@ -230,26 +223,20 @@ class Mat33 {
     override fun hashCode(): Int {
         val prime = 31
         var result = 1
-        result = prime * result + (ex?.hashCode() ?: 0)
-        result = prime * result + (ey?.hashCode() ?: 0)
-        result = prime * result + (ez?.hashCode() ?: 0)
+        result = prime * result + ex.hashCode()
+        result = prime * result + ey.hashCode()
+        result = prime * result + ez.hashCode()
         return result
     }
 
-    override fun equals(obj: Any?): Boolean {
-        if (this === obj) return true
-        if (obj == null) return false
-        if (this::class != obj::class) return false
-        val other = obj as Mat33?
-        if (ex == null) {
-            if (other?.ex != null) return false
-        } else if (ex != other?.ex) return false
-        if (ey == null) {
-            if (other?.ey != null) return false
-        } else if (ey != other?.ey) return false
-        if (ez == null) {
-            if (other?.ez != null) return false
-        } else if (ez != other?.ez) return false
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null) return false
+        if (this::class != other::class) return false
+        val oth = other as Mat33?
+        if (ex != oth?.ex) return false
+        if (ey != oth?.ey) return false
+        if (ez != oth?.ez) return false
         return true
     }
 
@@ -258,17 +245,20 @@ class Mat33 {
         //@ThreadLocal
         val IDENTITY = Mat33(Vec3(1f, 0f, 0f), Vec3(0f, 1f, 0f), Vec3(0f, 0f, 1f))
 
-        // / Multiply a matrix times a vector.
-
+        /**
+         * Multiply a matrix [A] by a vector [v].
+         */
         fun mul(A: Mat33, v: Vec3): Vec3 {
-            return Vec3(v.x * A.ex.x + v.y * A.ey.x + v.z + A.ez.x, v.x * A.ex.y + v.y * A.ey.y + v.z * A.ez.y, v.x * A.ex.z + v.y * A.ey.z + v.z * A.ez.z)
+            return Vec3(
+                v.x * A.ex.x + v.y * A.ey.x + v.z + A.ez.x,
+                v.x * A.ex.y + v.y * A.ey.y + v.z * A.ez.y,
+                v.x * A.ex.z + v.y * A.ey.z + v.z * A.ez.z
+            )
         }
-
 
         fun mul22(A: Mat33, v: Vec2): Vec2 {
             return Vec2(A.ex.x * v.x + A.ey.x * v.y, A.ex.y * v.x + A.ey.y * v.y)
         }
-
 
         fun mul22ToOut(A: Mat33, v: Vec2, out: Vec2) {
             val tempx = A.ex.x * v.x + A.ey.x * v.y
@@ -276,13 +266,11 @@ class Mat33 {
             out.x = tempx
         }
 
-
         fun mul22ToOutUnsafe(A: Mat33, v: Vec2, out: Vec2) {
             assert(v !== out)
             out.y = A.ex.y * v.x + A.ey.y * v.y
             out.x = A.ex.x * v.x + A.ey.x * v.y
         }
-
 
         fun mulToOut(A: Mat33, v: Vec3, out: Vec3) {
             val tempy = v.x * A.ex.y + v.y * A.ey.y + v.z * A.ez.y
@@ -292,14 +280,12 @@ class Mat33 {
             out.z = tempz
         }
 
-
         fun mulToOutUnsafe(A: Mat33, v: Vec3, out: Vec3) {
             assert(out !== v)
             out.x = v.x * A.ex.x + v.y * A.ey.x + v.z * A.ez.x
             out.y = v.x * A.ex.y + v.y * A.ey.y + v.z * A.ez.y
             out.z = v.x * A.ex.z + v.y * A.ey.z + v.z * A.ez.z
         }
-
 
         fun setScaleTransform(scale: Float, out: Mat33) {
             out.ex.x = scale

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/common/MathUtils.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/common/MathUtils.kt
@@ -43,7 +43,6 @@
  * misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  */
-
 package org.jbox2d.common
 
 import kotlin.math.*
@@ -52,274 +51,230 @@ import kotlin.random.*
 /**
  * A few math methods that don't fit very well anywhere else.
  */
-class MathUtils : PlatformMathUtils() {
-    companion object {
+object MathUtils : PlatformMathUtils() {
 
-        val PI = kotlin.math.PI.toFloat()
+    val PI = kotlin.math.PI.toFloat()
+    val TWOPI = (kotlin.math.PI * 2).toFloat()
+    val INV_PI = 1f / PI
+    val HALF_PI = PI / 2
+    val QUARTER_PI = PI / 4
+    val THREE_HALVES_PI = TWOPI - HALF_PI
 
-        val TWOPI = (kotlin.math.PI * 2).toFloat()
+    /** Degrees to radians conversion factor */
+    val DEG2RAD = PI / 180
+    /** Radians to degrees conversion factor */
+    val RAD2DEG = 180 / PI
 
-        val INV_PI = 1f / PI
+    val sinLUT = FloatArray(Settings.SINCOS_LUT_LENGTH) {
+        sin((it * Settings.SINCOS_LUT_PRECISION).toDouble()).toFloat()
+    }
 
-        val HALF_PI = PI / 2
+    fun sin(x: Float): Float {
+        return if (Settings.SINCOS_LUT_ENABLED) {
+            sinLUT(x)
+        } else {
+            sin(x.toDouble()).toFloat()
+        }
+    }
 
-        val QUARTER_PI = PI / 4
+    fun sinLUT(x: Float): Float {
+        var x = x
+        x %= TWOPI
 
-        val THREE_HALVES_PI = TWOPI - HALF_PI
-
-        /**
-         * Degrees to radians conversion factor
-         */
-
-        val DEG2RAD = PI / 180
-
-        /**
-         * Radians to degrees conversion factor
-         */
-
-        val RAD2DEG = 180 / PI
-
-
-        val sinLUT = FloatArray(Settings.SINCOS_LUT_LENGTH) {
-            kotlin.math.sin((it * Settings.SINCOS_LUT_PRECISION).toDouble()).toFloat()
+        if (x < 0) {
+            x += TWOPI
         }
 
-        fun sin(x: Float): Float {
-            return if (Settings.SINCOS_LUT_ENABLED) {
-                sinLUT(x)
+        if (Settings.SINCOS_LUT_LERP) {
+            x /= Settings.SINCOS_LUT_PRECISION
+
+            val index = x.toInt()
+            if (index != 0) {
+                x %= index.toFloat()
+            }
+
+            // the next index is 0
+            return if (index == Settings.SINCOS_LUT_LENGTH - 1) {
+                (1 - x) * sinLUT[index] + x * sinLUT[0]
             } else {
-                kotlin.math.sin(x.toDouble()).toFloat()
+                (1 - x) * sinLUT[index] + x * sinLUT[index + 1]
             }
+        } else {
+            return sinLUT[round(x / Settings.SINCOS_LUT_PRECISION) % Settings.SINCOS_LUT_LENGTH]
         }
+    }
 
+    fun cos(x: Float): Float {
+        return if (Settings.SINCOS_LUT_ENABLED) {
+            sinLUT(HALF_PI - x)
+        } else {
+            cos(x.toDouble()).toFloat()
+        }
+    }
 
-        fun sinLUT(x: Float): Float {
-            var x = x
-            x %= TWOPI
+    fun abs(x: Float): Float {
+        return if (Settings.FAST_ABS) {
+            if (x > 0) x else -x
+        } else {
+            kotlin.math.abs(x)
+        }
+    }
 
-            if (x < 0) {
-                x += TWOPI
+    fun fastAbs(x: Float): Float {
+        return if (x > 0) x else -x
+    }
+
+    fun abs(x: Int): Int {
+        val y = x shr 31
+        return (x xor y) - y
+    }
+
+    fun floor(x: Float): Int = if (Settings.FAST_FLOOR) fastFloor(x) else floor(x.toDouble()).toInt()
+
+    fun fastFloor(x: Float): Int {
+        val y = x.toInt()
+        return if (x < y) y - 1 else y
+    }
+
+    fun ceil(x: Float): Int = if (Settings.FAST_CEIL) fastCeil(x) else ceil(x.toDouble()).toInt()
+
+    fun fastCeil(x: Float): Int {
+        val y = x.toInt()
+        return if (x > y) y + 1 else y
+    }
+
+    fun round(x: Float): Int = if (Settings.FAST_ROUND) floor(x + .5f) else round(x.toDouble()).toInt()
+
+    /**
+     * Rounds up the value [x] to the nearest higher power^2 value.
+     */
+    fun ceilPowerOf2(x: Int): Int {
+        var pow2 = 1
+        while (pow2 < x) pow2 = pow2 shl 1
+        return pow2
+    }
+
+    fun max(a: Float, b: Float): Float = if (a > b) a else b
+    fun max(a: Int, b: Int): Int = if (a > b) a else b
+    fun min(a: Float, b: Float): Float = if (a < b) a else b
+    fun min(a: Int, b: Int): Int = if (a < b) a else b
+
+    fun map(
+        value: Float, fromMin: Float, fromMax: Float,
+        toMin: Float, toMax: Float
+    ): Float {
+        val mult = (value - fromMin) / (fromMax - fromMin)
+        val res = toMin + mult * (toMax - toMin)
+        return res
+    }
+
+    /**
+     * Returns the closest value to 'a' that is in between 'low' and 'high'
+     */
+    fun clamp(a: Float, low: Float, high: Float): Float = max(low, min(a, high))
+
+    fun clamp(a: Vec2, low: Vec2, high: Vec2): Vec2 {
+        val min = Vec2()
+        min.x = if (a.x < high.x) a.x else high.x
+        min.y = if (a.y < high.y) a.y else high.y
+        min.x = if (low.x > min.x) low.x else min.x
+        min.y = if (low.y > min.y) low.y else min.y
+        return min
+    }
+
+    fun clampToOut(a: Vec2, low: Vec2, high: Vec2, dest: Vec2) {
+        dest.x = if (a.x < high.x) a.x else high.x
+        dest.y = if (a.y < high.y) a.y else high.y
+        dest.x = if (low.x > dest.x) low.x else dest.x
+        dest.y = if (low.y > dest.y) low.y else dest.y
+    }
+
+    /**
+     * Next Largest Power of 2: Given a binary integer value x, the next largest power of 2 can be
+     * computed by a SWAR algorithm that recursively "folds" the upper bits into the lower bits. This
+     * process yields a bit vector with the same most significant 1 as x, but all 1's below it. Adding
+     * 1 to that value yields the next largest power of 2.
+     */
+    fun nextPowerOfTwo(x: Int): Int {
+        var x = x
+        x = x or (x shr 1)
+        x = x or (x shr 2)
+        x = x or (x shr 4)
+        x = x or (x shr 8)
+        x = x or (x shr 16)
+        return x + 1
+    }
+
+    fun isPowerOfTwo(x: Int): Boolean {
+        return x > 0 && x and x - 1 == 0
+    }
+
+    fun pow(a: Float, b: Float): Float {
+        return if (Settings.FAST_POW) {
+            fastPow(a, b)
+        } else {
+            a.toDouble().pow(b.toDouble()).toFloat()
+        }
+    }
+
+    fun atan2(y: Float, x: Float): Float {
+        return if (Settings.FAST_ATAN2) {
+            fastAtan2(y, x)
+        } else {
+            atan2(y.toDouble(), x.toDouble()).toFloat()
+        }
+    }
+
+    fun fastAtan2(y: Float, x: Float): Float {
+        if (x == 0.0f) {
+            if (y > 0.0f) return HALF_PI
+            return if (y == 0.0f) 0.0f else -HALF_PI
+        }
+        val atan: Float
+        val z = y / x
+        if (abs(z) < 1.0f) {
+            atan = z / (1.0f + 0.28f * z * z)
+            if (x < 0.0f) {
+                return if (y < 0.0f) atan - PI else atan + PI
             }
-
-            if (Settings.SINCOS_LUT_LERP) {
-
-                x /= Settings.SINCOS_LUT_PRECISION
-
-                val index = x.toInt()
-
-                if (index != 0) {
-                    x %= index.toFloat()
-                }
-
-                // the next index is 0
-                return if (index == Settings.SINCOS_LUT_LENGTH - 1) {
-                    (1 - x) * sinLUT[index] + x * sinLUT[0]
-                } else {
-                    (1 - x) * sinLUT[index] + x * sinLUT[index + 1]
-                }
-
-            } else {
-                return sinLUT[MathUtils.round(x / Settings.SINCOS_LUT_PRECISION) % Settings.SINCOS_LUT_LENGTH]
-            }
+        } else {
+            atan = HALF_PI - z / (z * z + 0.28f)
+            if (y < 0.0f) return atan - PI
         }
+        return atan
+    }
 
-
-        fun cos(x: Float): Float {
-            return if (Settings.SINCOS_LUT_ENABLED) {
-                sinLUT(HALF_PI - x)
-            } else {
-                kotlin.math.cos(x.toDouble()).toFloat()
-            }
+    fun reduceAngle(theta: Float): Float {
+        var theta = theta
+        theta %= TWOPI
+        if (abs(theta) > PI) {
+            theta -= TWOPI
         }
-
-
-        fun abs(x: Float): Float {
-            return if (Settings.FAST_ABS) {
-                if (x > 0) x else -x
-            } else {
-                kotlin.math.abs(x)
-            }
+        if (abs(theta) > HALF_PI) {
+            theta = PI - theta
         }
+        return theta
+    }
 
+    fun randomFloat(argLow: Float, argHigh: Float): Float {
+        return Random.nextFloat() * (argHigh - argLow) + argLow
+    }
 
-        fun fastAbs(x: Float): Float {
-            return if (x > 0) x else -x
-        }
+    fun randomFloat(r: Random, argLow: Float, argHigh: Float): Float {
+        return r.nextFloat() * (argHigh - argLow) + argLow
+    }
 
+    fun sqrt(x: Float): Float {
+        return sqrt(x.toDouble()).toFloat()
+    }
 
-        fun abs(x: Int): Int {
-            val y = x shr 31
-            return (x xor y) - y
-        }
+    fun distanceSquared(v1: Vec2, v2: Vec2): Float {
+        val dx = v1.x - v2.x
+        val dy = v1.y - v2.y
+        return dx * dx + dy * dy
+    }
 
-
-        fun floor(x: Float): Int = if (Settings.FAST_FLOOR) fastFloor(x) else floor(x.toDouble()).toInt()
-
-
-        fun fastFloor(x: Float): Int {
-            val y = x.toInt()
-            return if (x < y) y - 1 else y
-        }
-
-
-        fun ceil(x: Float): Int = if (Settings.FAST_CEIL) fastCeil(x) else ceil(x.toDouble()).toInt()
-
-
-        fun fastCeil(x: Float): Int {
-            val y = x.toInt()
-            return if (x > y) y + 1 else y
-        }
-
-
-        fun round(x: Float): Int = if (Settings.FAST_ROUND) floor(x + .5f) else round(x.toDouble()).toInt()
-
-        /**
-         * Rounds up the value to the nearest higher power^2 value.
-         *
-         * @param x
-         * @return power^2 value
-         */
-
-        fun ceilPowerOf2(x: Int): Int {
-            var pow2 = 1
-            while (pow2 < x) pow2 = pow2 shl 1
-            return pow2
-        }
-
-
-        fun max(a: Float, b: Float): Float = if (a > b) a else b
-        fun max(a: Int, b: Int): Int = if (a > b) a else b
-        fun min(a: Float, b: Float): Float = if (a < b) a else b
-        fun min(a: Int, b: Int): Int = if (a < b) a else b
-
-        fun map(`val`: Float, fromMin: Float, fromMax: Float,
-                toMin: Float, toMax: Float): Float {
-            val mult = (`val` - fromMin) / (fromMax - fromMin)
-            val res = toMin + mult * (toMax - toMin)
-            return res
-        }
-
-        /** Returns the closest value to 'a' that is in between 'low' and 'high'  */
-
-        fun clamp(a: Float, low: Float, high: Float): Float = max(low, min(a, high))
-
-
-        fun clamp(a: Vec2, low: Vec2, high: Vec2): Vec2 {
-            val min = Vec2()
-            min.x = if (a.x < high.x) a.x else high.x
-            min.y = if (a.y < high.y) a.y else high.y
-            min.x = if (low.x > min.x) low.x else min.x
-            min.y = if (low.y > min.y) low.y else min.y
-            return min
-        }
-
-
-        fun clampToOut(a: Vec2, low: Vec2, high: Vec2, dest: Vec2) {
-            dest.x = if (a.x < high.x) a.x else high.x
-            dest.y = if (a.y < high.y) a.y else high.y
-            dest.x = if (low.x > dest.x) low.x else dest.x
-            dest.y = if (low.y > dest.y) low.y else dest.y
-        }
-
-        /**
-         * Next Largest Power of 2: Given a binary integer value x, the next largest power of 2 can be
-         * computed by a SWAR algorithm that recursively "folds" the upper bits into the lower bits. This
-         * process yields a bit vector with the same most significant 1 as x, but all 1's below it. Adding
-         * 1 to that value yields the next largest power of 2.
-         */
-
-        fun nextPowerOfTwo(x: Int): Int {
-            var x = x
-            x = x or (x shr 1)
-            x = x or (x shr 2)
-            x = x or (x shr 4)
-            x = x or (x shr 8)
-            x = x or (x shr 16)
-            return x + 1
-        }
-
-
-        fun isPowerOfTwo(x: Int): Boolean {
-            return x > 0 && x and x - 1 == 0
-        }
-
-
-        fun pow(a: Float, b: Float): Float {
-            return if (Settings.FAST_POW) {
-                PlatformMathUtils.fastPow(a, b)
-            } else {
-                a.toDouble().pow(b.toDouble()).toFloat()
-            }
-        }
-
-
-        fun atan2(y: Float, x: Float): Float {
-            return if (Settings.FAST_ATAN2) {
-                fastAtan2(y, x)
-            } else {
-                kotlin.math.atan2(y.toDouble(), x.toDouble()).toFloat()
-            }
-        }
-
-
-        fun fastAtan2(y: Float, x: Float): Float {
-            if (x == 0.0f) {
-                if (y > 0.0f) return HALF_PI
-                return if (y == 0.0f) 0.0f else -HALF_PI
-            }
-            val atan: Float
-            val z = y / x
-            if (abs(z) < 1.0f) {
-                atan = z / (1.0f + 0.28f * z * z)
-                if (x < 0.0f) {
-                    return if (y < 0.0f) atan - PI else atan + PI
-                }
-            } else {
-                atan = HALF_PI - z / (z * z + 0.28f)
-                if (y < 0.0f) return atan - PI
-            }
-            return atan
-        }
-
-
-        fun reduceAngle(theta: Float): Float {
-            var theta = theta
-            theta %= TWOPI
-            if (abs(theta) > PI) {
-                theta = theta - TWOPI
-            }
-            if (abs(theta) > HALF_PI) {
-                theta = PI - theta
-            }
-            return theta
-        }
-
-
-        fun randomFloat(argLow: Float, argHigh: Float): Float {
-
-            return kotlin.random.Random.nextFloat() * (argHigh - argLow) + argLow
-        }
-
-
-        fun randomFloat(r: Random, argLow: Float, argHigh: Float): Float {
-            return r.nextFloat() * (argHigh - argLow) + argLow
-        }
-
-
-        fun sqrt(x: Float): Float {
-            return kotlin.math.sqrt(x.toDouble()).toFloat()
-        }
-
-
-        fun distanceSquared(v1: Vec2, v2: Vec2): Float {
-            val dx = v1.x - v2.x
-            val dy = v1.y - v2.y
-            return dx * dx + dy * dy
-        }
-
-
-        fun distance(v1: Vec2, v2: Vec2): Float {
-            return sqrt(distanceSquared(v1, v2))
-        }
+    fun distance(v1: Vec2, v2: Vec2): Float {
+        return sqrt(distanceSquared(v1, v2))
     }
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/common/OBBViewportTransform.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/common/OBBViewportTransform.kt
@@ -50,10 +50,7 @@ class OBBViewportTransform : IViewportTransform {
         }
 
     /**
-     * Gets the transform of the viewport, transforms around the center. Not a copy.
-     */
-    /**
-     * Sets the transform of the viewport. Transforms about the center.
+     * Transform of the viewport, transforms around the center. Not a copy.
      */
     var transform: Mat22
         get() = box.R
@@ -62,7 +59,6 @@ class OBBViewportTransform : IViewportTransform {
         }
 
     private val inv = Mat22()
-
     private val inv2 = Mat22()
 
     class OBB {

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/common/RaycastResult.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/common/RaycastResult.kt
@@ -23,8 +23,6 @@
  */
 package org.jbox2d.common
 
-// updated to rev 100
-
 class RaycastResult {
 
     var lambda = 0.0f

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/common/Rot.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/common/Rot.kt
@@ -33,15 +33,11 @@ import org.jbox2d.internal.*
  */
 class Rot {
 
-
-    var s: Float = 0.toFloat()
-
-    var c: Float = 0.toFloat() // sin and cos
+    var s: Float = 0.toFloat() // sin
+    var c: Float = 0.toFloat() // cos
 
     val angleRadians: Float get() = MathUtils.atan2(s, c)
-
     val angleDegrees: Float get() = angleRadians * MathUtils.RAD2DEG
-
     val angle: Angle get() = angleRadians.radians
 
     constructor() {
@@ -91,7 +87,6 @@ class Rot {
         yAxis.set(-s, c)
     }
 
-    // @Override // annotation omitted for GWT-compatibility
     fun clone(): Rot {
         val copy = Rot()
         copy.s = s
@@ -107,18 +102,12 @@ class Rot {
             out.c = tempc
         }
 
-
         fun mulUnsafe(q: Rot, r: Rot, out: Rot) {
             assert(r !== out)
             assert(q !== out)
-            // [qc -qs] * [rc -rs] = [qc*rc-qs*rs -qc*rs-qs*rc]
-            // [qs qc] [rs rc] [qs*rc+qc*rs -qs*rs+qc*rc]
-            // s = qs * rc + qc * rs
-            // c = qc * rc - qs * rs
             out.s = q.s * r.c + q.c * r.s
             out.c = q.c * r.c - q.s * r.s
         }
-
 
         fun mulTrans(q: Rot, r: Rot, out: Rot) {
             val tempc = q.c * r.c + q.s * r.s
@@ -126,16 +115,10 @@ class Rot {
             out.c = tempc
         }
 
-
         fun mulTransUnsafe(q: Rot, r: Rot, out: Rot) {
-            // [ qc qs] * [rc -rs] = [qc*rc+qs*rs -qc*rs+qs*rc]
-            // [-qs qc] [rs rc] [-qs*rc+qc*rs qs*rs+qc*rc]
-            // s = qc * rs - qs * rc
-            // c = qc * rc + qs * rs
             out.s = q.c * r.s - q.s * r.c
             out.c = q.c * r.c + q.s * r.s
         }
-
 
         fun mulToOut(q: Rot, v: Vec2, out: Vec2) {
             val tempy = q.s * v.x + q.c * v.y
@@ -143,19 +126,16 @@ class Rot {
             out.y = tempy
         }
 
-
         fun mulToOutUnsafe(q: Rot, v: Vec2, out: Vec2) {
             out.x = q.c * v.x - q.s * v.y
             out.y = q.s * v.x + q.c * v.y
         }
-
 
         fun mulTrans(q: Rot, v: Vec2, out: Vec2) {
             val tempy = -q.s * v.x + q.c * v.y
             out.x = q.c * v.x + q.s * v.y
             out.y = tempy
         }
-
 
         fun mulTransUnsafe(q: Rot, v: Vec2, out: Vec2) {
             out.x = q.c * v.x + q.s * v.y

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/common/Settings.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/common/Settings.kt
@@ -23,21 +23,18 @@
  */
 package org.jbox2d.common
 
-import org.jbox2d.internal.*
 import kotlin.native.concurrent.ThreadLocal
 
 /**
- * Global tuning constants based on MKS units and various integer maximums (vertices per shape,
- * pairs, etc.).
+ * Global tuning constants based on MKS units and various integer maximums
+ * (vertices per shape, pairs, etc.).
  */
 object Settings {
 
     /** A "close to zero" float epsilon value for use  */
-
     val EPSILON = 1.1920928955078125E-7f
 
-    /** Pi.  */
-
+    /** PI.  */
     val PI = kotlin.math.PI.toFloat()
 
     // JBox2D specific settings
@@ -52,7 +49,6 @@ object Settings {
     var FAST_CEIL = true
 
     @ThreadLocal
-    //var FAST_ROUND = true
     var FAST_ROUND = false
 
     @ThreadLocal
@@ -66,8 +62,9 @@ object Settings {
 
     @ThreadLocal
     var SINCOS_LUT_ENABLED = true
+
     /**
-     * smaller the precision, the larger the table. If a small table is used (eg, precision is .006 or
+     * Smaller the precision, the larger the table. If a small table is used (eg, precision is .006 or
      * greater), make sure you set the table to lerp it's results. Accuracy chart is in the MathUtils
      * source. Or, run the tests yourself in [SinCosTest].  Good lerp precision
      * values:
@@ -94,12 +91,12 @@ object Settings {
     val SINCOS_LUT_PRECISION = .00011f
 
     val SINCOS_LUT_LENGTH = kotlin.math.ceil(kotlin.math.PI * 2 / SINCOS_LUT_PRECISION).toInt()
+
     /**
      * Use if the table's precision is large (eg .006 or greater). Although it is more expensive, it
      * greatly increases accuracy. Look in the MathUtils source for some test results on the accuracy
      * and speed of lerp vs non lerp. Or, run the tests yourself in [SinCosTest].
      */
-
     @ThreadLocal
     var SINCOS_LUT_LERP = false
 
@@ -109,14 +106,12 @@ object Settings {
     /**
      * The maximum number of contact points between two convex shapes.
      */
-
     @ThreadLocal
     var maxManifoldPoints = 2
 
     /**
      * The maximum number of vertices on a convex polygon.
      */
-
     @ThreadLocal
     var maxPolygonVertices = 8
 
@@ -124,7 +119,6 @@ object Settings {
      * This is used to fatten AABBs in the dynamic tree. This allows proxies to move by a small amount
      * without triggering a tree adjustment. This is in meters.
      */
-
     @ThreadLocal
     var aabbExtension = 0.1f
 
@@ -132,7 +126,6 @@ object Settings {
      * This is used to fatten AABBs in the dynamic tree. This is used to predict the future position
      * based on the current displacement. This is a dimensionless multiplier.
      */
-
     @ThreadLocal
     var aabbMultiplier = 2.0f
 
@@ -140,7 +133,6 @@ object Settings {
      * A small length used as a collision and constraint tolerance. Usually it is chosen to be
      * numerically significant, but visually insignificant.
      */
-
     @ThreadLocal
     var linearSlop = 0.005f
 
@@ -148,7 +140,6 @@ object Settings {
      * A small angle used as a collision and constraint tolerance. Usually it is chosen to be
      * numerically significant, but visually insignificant.
      */
-
     @ThreadLocal
     var angularSlop = 2.0f / 180.0f * PI
 
@@ -157,12 +148,10 @@ object Settings {
      * means polygons will have and insufficient for continuous collision. Making it larger may create
      * artifacts for vertex collision.
      */
-
     @ThreadLocal
     var polygonRadius = 2.0f * linearSlop
 
     /** Maximum number of sub-steps per contact in continuous physics simulation.  */
-
     @ThreadLocal
     var maxSubSteps = 8
 
@@ -171,7 +160,6 @@ object Settings {
     /**
      * Maximum number of contacts to be handled to solve a TOI island.
      */
-
     @ThreadLocal
     var maxTOIContacts = 32
 
@@ -179,7 +167,6 @@ object Settings {
      * A velocity threshold for elastic collisions. Any collision with a relative linear velocity
      * below this threshold will be treated as inelastic.
      */
-
     @ThreadLocal
     var velocityThreshold = 1.0f
 
@@ -187,7 +174,6 @@ object Settings {
      * The maximum linear position correction used when solving constraints. This helps to prevent
      * overshoot.
      */
-
     @ThreadLocal
     var maxLinearCorrection = 0.2f
 
@@ -195,7 +181,6 @@ object Settings {
      * The maximum angular position correction used when solving constraints. This helps to prevent
      * overshoot.
      */
-
     @ThreadLocal
     var maxAngularCorrection = 8.0f / 180.0f * PI
 
@@ -203,7 +188,6 @@ object Settings {
      * The maximum linear velocity of a body. This limit is very large and is used to prevent
      * numerical problems. You shouldn't need to adjust this.
      */
-
     @ThreadLocal
     var maxTranslation = 2.0f
 
@@ -214,7 +198,6 @@ object Settings {
      * The maximum angular velocity of a body. This limit is very large and is used to prevent
      * numerical problems. You shouldn't need to adjust this.
      */
-
     @ThreadLocal
     var maxRotation = 0.5f * PI
 
@@ -225,7 +208,6 @@ object Settings {
      * This scale factor controls how fast overlap is resolved. Ideally this would be 1 so that
      * overlap is removed in one time step. However using values close to 1 often lead to overshoot.
      */
-
     @ThreadLocal
     var baumgarte = 0.2f
 
@@ -238,21 +220,18 @@ object Settings {
     /**
      * The time that a body must be still before it will go to sleep.
      */
-
     @ThreadLocal
     var timeToSleep = 0.5f
 
     /**
      * A body cannot sleep if its linear velocity is above this tolerance.
      */
-
     @ThreadLocal
     var linearSleepTolerance = 0.01f
 
     /**
      * A body cannot sleep if its angular velocity is above this tolerance.
      */
-
     @ThreadLocal
     var angularSleepTolerance = 2.0f / 180.0f * PI
 
@@ -261,31 +240,26 @@ object Settings {
     /**
      * A symbolic constant that stands for particle allocation error.
      */
-
     val invalidParticleIndex = -1
 
     /**
      * The standard distance between particles, divided by the particle radius.
      */
-
     val particleStride = 0.75f
 
     /**
      * The minimum particle weight that produces pressure.
      */
-
     val minParticleWeight = 1.0f
 
     /**
      * The upper limit for particle weight used in pressure calculation.
      */
-
     val maxParticleWeight = 5.0f
 
     /**
      * The maximum distance between particles in a triad, divided by the particle radius.
      */
-
     val maxTriadDistance = 2
 
     val maxTriadDistanceSquared = maxTriadDistance * maxTriadDistance
@@ -293,30 +267,19 @@ object Settings {
     /**
      * The initial size of particle data buffers.
      */
-
     val minParticleBufferCapacity = 256
 
 
     /**
      * Friction mixing law. Feel free to customize this. TODO djm: add customization
-     *
-     * @param friction1
-     * @param friction2
-     * @return
      */
-
     fun mixFriction(friction1: Float, friction2: Float): Float {
         return MathUtils.sqrt(friction1 * friction2)
     }
 
     /**
      * Restitution mixing law. Feel free to customize this. TODO djm: add customization
-     *
-     * @param restitution1
-     * @param restitution2
-     * @return
      */
-
     fun mixRestitution(restitution1: Float, restitution2: Float): Float {
         return if (restitution1 > restitution2) restitution1 else restitution2
     }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/common/Sweep.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/common/Sweep.kt
@@ -32,22 +32,18 @@ import org.jbox2d.internal.*
  */
 class Sweep {
 
-    /** Local center of mass position  */
-
+    /** Local center of mass position */
     val localCenter: Vec2 = Vec2()
-    /** Center world positions  */
 
+    /** Center world positions */
     val c0: Vec2 = Vec2()
-
     val c: Vec2 = Vec2()
-    /** World angles  */
 
+    /** World angles */
     var a0: Float = 0.toFloat()
-
     var a: Float = 0.toFloat()
 
-    /** Fraction of the current time step in the range [0,1] c0 and a0 are the positions at alpha0.  */
-
+    /** Fraction of the current time step in the range [0,1] c0 and a0 are the positions at alpha0. */
     var alpha0: Float = 0.toFloat()
 
     override fun toString(): String {
@@ -77,21 +73,16 @@ class Sweep {
     /**
      * Get the interpolated transform at a specific time.
      *
-     * @param xf the result is placed here - must not be null
-     * @param t the normalized time in [0,1].
+     * @param xf the result is placed here
+     * @param beta the normalized time in [0,1].
      */
     fun getTransform(xf: Transform, beta: Float) {
-        assert(xf != null)
-        // xf->p = (1.0f - beta) * c0 + beta * c;
-        // float32 angle = (1.0f - beta) * a0 + beta * a;
-        // xf->q.Set(angle);
         xf.p.x = (1.0f - beta) * c0.x + beta * c.x
         xf.p.y = (1.0f - beta) * c0.y + beta * c.y
         val angle = (1.0f - beta) * a0 + beta * a
         xf.q.setRadians(angle)
 
         // Shift to origin
-        // xf->p -= b2Mul(xf->q, localCenter);
         val q = xf.q
         xf.p.x -= q.c * localCenter.x - q.s * localCenter.y
         xf.p.y -= q.s * localCenter.x + q.c * localCenter.y
@@ -104,10 +95,6 @@ class Sweep {
      */
     fun advance(alpha: Float) {
         assert(alpha0 < 1.0f)
-        // float32 beta = (alpha - alpha0) / (1.0f - alpha0);
-        // c0 += beta * (c - c0);
-        // a0 += beta * (a - a0);
-        // alpha0 = alpha;
         val beta = (alpha - alpha0) / (1.0f - alpha0)
         c0.x += beta * (c.x - c0.x)
         c0.y += beta * (c.y - c0.y)

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/common/Transform.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/common/Transform.kt
@@ -26,8 +26,6 @@ package org.jbox2d.common
 import com.soywiz.korma.geom.*
 import org.jbox2d.internal.*
 
-// updated to rev 100
-
 /**
  * A transform contains translation and rotation. It is used to represent the position and
  * orientation of rigid frames.
@@ -35,11 +33,9 @@ import org.jbox2d.internal.*
 class Transform {
 
     /** The translation caused by the transform  */
-
     val p: Vec2
 
     /** A matrix representing a rotation  */
-
     val q: Rot
 
     /** The default constructor.  */
@@ -68,18 +64,12 @@ class Transform {
     }
 
     /**
-     * Set this based on the position and angle.
-     *
-     * @param p
-     * @param angle
+     * Set this based on the position [p] and [angle].
      */
     fun set(p: Vec2, angle: Angle) = this.setRadians(p, angle.radians.toFloat())
 
     /**
-     * Set this based on the position and angle in radians.
-     *
-     * @param p
-     * @param angleRadians
+     * Set this based on the position [p] and angle in radians [angleRadians].
      */
     fun setRadians(p: Vec2, angleRadians: Float) {
         this.p.set(p)
@@ -87,10 +77,7 @@ class Transform {
     }
 
     /**
-     * Set this based on the position and angle in degrees.
-     *
-     * @param p
-     * @param angle
+     * Set this based on the position [p] and angle in degrees [angleDegrees].
      */
     fun setDegrees(p: Vec2, angleDegrees: Float) = setRadians(p, angleDegrees * MathUtils.DEG2RAD)
 
@@ -113,13 +100,11 @@ class Transform {
             return Vec2(T.q.c * v.x - T.q.s * v.y + T.p.x, T.q.s * v.x + T.q.c * v.y + T.p.y)
         }
 
-
         fun mulToOut(T: Transform, v: Vec2, out: Vec2) {
             val tempy = T.q.s * v.x + T.q.c * v.y + T.p.y
             out.x = T.q.c * v.x - T.q.s * v.y + T.p.x
             out.y = tempy
         }
-
 
         fun mulToOutUnsafe(T: Transform, v: Vec2, out: Vec2) {
             assert(v !== out)
@@ -127,13 +112,11 @@ class Transform {
             out.y = T.q.s * v.x + T.q.c * v.y + T.p.y
         }
 
-
         fun mulTrans(T: Transform, v: Vec2): Vec2 {
             val px = v.x - T.p.x
             val py = v.y - T.p.y
             return Vec2(T.q.c * px + T.q.s * py, -T.q.s * px + T.q.c * py)
         }
-
 
         fun mulTransToOut(T: Transform, v: Vec2, out: Vec2) {
             val px = v.x - T.p.x
@@ -143,7 +126,6 @@ class Transform {
             out.y = tempy
         }
 
-
         fun mulTransToOutUnsafe(T: Transform, v: Vec2, out: Vec2) {
             assert(v !== out)
             val px = v.x - T.p.x
@@ -151,7 +133,6 @@ class Transform {
             out.x = T.q.c * px + T.q.s * py
             out.y = -T.q.s * px + T.q.c * py
         }
-
 
         fun mul(A: Transform, B: Transform): Transform {
             val C = Transform()
@@ -161,14 +142,12 @@ class Transform {
             return C
         }
 
-
         fun mulToOut(A: Transform, B: Transform, out: Transform) {
             assert(out !== A)
             Rot.mul(A.q, B.q, out.q)
             Rot.mulToOut(A.q, B.p, out.p)
             out.p.addLocal(A.p)
         }
-
 
         fun mulToOutUnsafe(A: Transform, B: Transform, out: Transform) {
             assert(out !== B)
@@ -186,14 +165,12 @@ class Transform {
             return C
         }
 
-
         fun mulTransToOut(A: Transform, B: Transform, out: Transform, pool: Vec2 = Vec2()) {
             assert(out !== A)
             Rot.mulTrans(A.q, B.q, out.q)
             pool.set(B.p).subLocal(A.p)
             Rot.mulTrans(A.q, pool, out.p)
         }
-
 
         fun mulTransToOutUnsafe(A: Transform, B: Transform, out: Transform, pool: Vec2 = Vec2()) {
             assert(out !== A)

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/common/Vec2.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/common/Vec2.kt
@@ -37,7 +37,7 @@ data class Vec2(
     /** True if the vector represents a pair of valid, non-infinite floating point numbers.  */
     val isValid: Boolean get() = !x.isNaN() && !x.isInfinite() && !y.isNaN() && !y.isInfinite()
 
-    constructor(toCopy: Vec2) : this(toCopy.x, toCopy.y) {}
+    constructor(toCopy: Vec2) : this(toCopy.x, toCopy.y)
 
     /** Zero out this vector.  */
     fun setZero() {
@@ -46,22 +46,23 @@ data class Vec2(
     }
 
     /** Set the vector component-wise.  */
-    fun set(x: Float, y: Float): Vec2 = this.apply {
+    fun set(x: Float, y: Float): Vec2 {
         this.x = x
         this.y = y
+        return this
     }
 
     inline fun set(x: Number, y: Number): Vec2 = set(x.toFloat(), y.toFloat())
 
     /** Set this vector to another vector.  */
-    fun set(v: Vec2): Vec2 = this.apply {
+    fun set(v: Vec2): Vec2 {
         this.x = v.x
         this.y = v.y
+        return this
     }
 
     /** Return the sum of this vector and another; does not alter either one.  */
     fun add(v: Vec2): Vec2 = Vec2(x + v.x, y + v.y)
-
 
     /** Return the difference of this vector and another; does not alter either one.  */
     fun sub(v: Vec2): Vec2 = Vec2(x - v.x, y - v.y)
@@ -152,12 +153,10 @@ data class Vec2(
 
         fun abs(a: Vec2): Vec2 = Vec2(MathUtils.abs(a.x), MathUtils.abs(a.y))
 
-
         fun absToOut(a: Vec2, out: Vec2) {
             out.x = MathUtils.abs(a.x)
             out.y = MathUtils.abs(a.y)
         }
-
 
         fun dot(a: Vec2, b: Vec2): Float = a.x * b.x + a.y * b.y
         fun cross(a: Vec2, b: Vec2): Float = a.x * b.y - a.y * b.x

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/common/Vec3.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/common/Vec3.kt
@@ -29,12 +29,9 @@ import org.jbox2d.internal.*
  * @author Daniel Murphy
  */
 data class Vec3(
-
-    var x: Float = 0.toFloat(),
-
-    var y: Float = 0.toFloat(),
-
-    var z: Float = 0.toFloat()
+    var x: Float = 0f,
+    var y: Float = 0f,
+    var z: Float = 0f
 ) {
     constructor(copy: Vec3) : this(copy.x, copy.y, copy.z)
 

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/BodyExt.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/BodyExt.kt
@@ -1,9 +1,9 @@
 package org.jbox2d.dynamics
 
 inline fun Body.forEachFixture(callback: (fixture: Fixture) -> Unit) {
-    var node = m_fixtureList
+    var node = fixtureList
     while (node != null) {
         callback(node)
-        node = node.m_next
+        node = node.next
     }
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/BodyType.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/BodyType.kt
@@ -26,13 +26,11 @@
  */
 package org.jbox2d.dynamics
 
-// updated to rev 100
-
 /**
  * The body type.
- * static: zero mass, zero velocity, may be manually moved
- * kinematic: zero mass, non-zero velocity set by user, moved by solver
- * dynamic: positive mass, non-zero velocity determined by forces, moved by solver
+ * - static: zero mass, zero velocity, may be manually moved
+ * - kinematic: zero mass, non-zero velocity set by user, moved by solver
+ * - dynamic: positive mass, non-zero velocity determined by forces, moved by solver
  *
  * @author daniel
  */

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/ContactManager.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/ContactManager.kt
@@ -28,24 +28,20 @@ import org.jbox2d.callbacks.ContactListener
 import org.jbox2d.callbacks.PairCallback
 import org.jbox2d.collision.broadphase.BroadPhase
 import org.jbox2d.dynamics.contacts.Contact
-import org.jbox2d.dynamics.contacts.ContactEdge
 
 /**
  * Delegate of World.
  *
  * @author Daniel Murphy
  */
-class ContactManager(private val pool: World, var m_broadPhase: BroadPhase) : PairCallback {
-    var m_contactList: Contact? = null
-    var m_contactCount: Int = 0
-    var m_contactFilter: ContactFilter = ContactFilter()
-    var m_contactListener: ContactListener? = null
+class ContactManager(private val pool: World, var broadPhase: BroadPhase) : PairCallback {
+    var contactList: Contact? = null
+    var contactCount: Int = 0
+    var contactFilter: ContactFilter = ContactFilter()
+    var contactListener: ContactListener? = null
 
     /**
      * Broad-phase callback.
-     *
-     * @param proxyUserDataA
-     * @param proxyUserDataB
      */
     override fun addPair(proxyUserDataA: Any?, proxyUserDataB: Any?) {
         val proxyA = proxyUserDataA as FixtureProxy?
@@ -57,24 +53,22 @@ class ContactManager(private val pool: World, var m_broadPhase: BroadPhase) : Pa
         var indexA = proxyA.childIndex
         var indexB = proxyB.childIndex
 
-        var bodyA = fixtureA!!.getBody()
-        var bodyB = fixtureB!!.getBody()
+        var bodyA = fixtureA!!.body
+        var bodyB = fixtureB!!.body
 
         // Are the fixtures on the same body?
-        if (bodyA == bodyB) {
-            return
-        }
+        if (bodyA == bodyB) return
 
         // TODO_ERIN use a hash table to remove a potential bottleneck when both
         // bodies have a lot of contacts.
         // Does a contact already exist?
-        var edge = bodyB!!.getContactList()
+        var edge = bodyB!!.contactList
         while (edge != null) {
             if (edge.other == bodyA) {
-                val fA = edge.contact!!.getFixtureA()
-                val fB = edge.contact!!.getFixtureB()
-                val iA = edge.contact!!.getChildIndexA()
-                val iB = edge.contact!!.getChildIndexB()
+                val fA = edge.contact!!.fixtureA
+                val fB = edge.contact!!.fixtureB
+                val iA = edge.contact!!.indexA
+                val iB = edge.contact!!.indexB
 
                 if (fA == fixtureA && iA == indexA && fB == fixtureB && iB == indexB) {
                     // A contact already exists.
@@ -91,12 +85,12 @@ class ContactManager(private val pool: World, var m_broadPhase: BroadPhase) : Pa
         }
 
         // Does a joint override collision? is at least one body dynamic?
-        if (bodyB.shouldCollide(bodyA!!) == false) {
+        if (!bodyB.shouldCollide(bodyA!!)) {
             return
         }
 
         // Check user filtering.
-        if (m_contactFilter != null && m_contactFilter!!.shouldCollide(fixtureA, fixtureB) == false) {
+        if (!contactFilter.shouldCollide(fixtureA, fixtureB)) {
             return
         }
 
@@ -104,44 +98,44 @@ class ContactManager(private val pool: World, var m_broadPhase: BroadPhase) : Pa
         val c = pool.popContact(fixtureA, indexA, fixtureB, indexB) ?: return
 
         // Contact creation may swap fixtures.
-        fixtureA = c.getFixtureA()
-        fixtureB = c.getFixtureB()
-        indexA = c.getChildIndexA()
-        indexB = c.getChildIndexB()
-        bodyA = fixtureA!!.getBody()
-        bodyB = fixtureB!!.getBody()
+        fixtureA = c.fixtureA
+        fixtureB = c.fixtureB
+        indexA = c.indexA
+        indexB = c.indexB
+        bodyA = fixtureA!!.body
+        bodyB = fixtureB!!.body
 
         // Insert into the world.
-        c.m_prev = null
-        c.m_next = m_contactList
-        if (m_contactList != null) {
-            m_contactList!!.m_prev = c
+        c.prev = null
+        c.next = contactList
+        if (contactList != null) {
+            contactList!!.prev = c
         }
-        m_contactList = c
+        contactList = c
 
         // Connect to island graph.
 
         // Connect to body A
-        c.m_nodeA.contact = c
-        c.m_nodeA.other = bodyB
+        c.nodeA.contact = c
+        c.nodeA.other = bodyB
 
-        c.m_nodeA.prev = null
-        c.m_nodeA.next = bodyA!!.m_contactList
-        if (bodyA.m_contactList != null) {
-            bodyA.m_contactList!!.prev = c.m_nodeA
+        c.nodeA.prev = null
+        c.nodeA.next = bodyA!!.contactList
+        if (bodyA.contactList != null) {
+            bodyA.contactList!!.prev = c.nodeA
         }
-        bodyA.m_contactList = c.m_nodeA
+        bodyA.contactList = c.nodeA
 
         // Connect to body B
-        c.m_nodeB.contact = c
-        c.m_nodeB.other = bodyA
+        c.nodeB.contact = c
+        c.nodeB.other = bodyA
 
-        c.m_nodeB.prev = null
-        c.m_nodeB.next = bodyB!!.m_contactList
-        if (bodyB.m_contactList != null) {
-            bodyB.m_contactList!!.prev = c.m_nodeB
+        c.nodeB.prev = null
+        c.nodeB.next = bodyB!!.contactList
+        if (bodyB.contactList != null) {
+            bodyB.contactList!!.prev = c.nodeB
         }
-        bodyB.m_contactList = c.m_nodeB
+        bodyB.contactList = c.nodeB
 
         // wake up the bodies
         if (!fixtureA.isSensor && !fixtureB.isSensor) {
@@ -149,65 +143,65 @@ class ContactManager(private val pool: World, var m_broadPhase: BroadPhase) : Pa
             bodyB.isAwake = true
         }
 
-        ++m_contactCount
+        ++contactCount
     }
 
     fun findNewContacts() {
-        m_broadPhase.updatePairs(this)
+        broadPhase.updatePairs(this)
     }
 
     fun destroy(c: Contact) {
-        val fixtureA = c.getFixtureA()
-        val fixtureB = c.getFixtureB()
-        val bodyA = fixtureA!!.getBody()
-        val bodyB = fixtureB!!.getBody()
+        val fixtureA = c.fixtureA
+        val fixtureB = c.fixtureB
+        val bodyA = fixtureA!!.body
+        val bodyB = fixtureB!!.body
 
-        if (m_contactListener != null && c.isTouching) {
-            m_contactListener!!.endContact(c)
+        if (contactListener != null && c.isTouching) {
+            contactListener!!.endContact(c)
         }
 
         // Remove from the world.
-        if (c.m_prev != null) {
-            c.m_prev!!.m_next = c.m_next
+        if (c.prev != null) {
+            c.prev!!.next = c.next
         }
 
-        if (c.m_next != null) {
-            c.m_next!!.m_prev = c.m_prev
+        if (c.next != null) {
+            c.next!!.prev = c.prev
         }
 
-        if (c === m_contactList) {
-            m_contactList = c.m_next
+        if (c === contactList) {
+            contactList = c.next
         }
 
         // Remove from body 1
-        if (c.m_nodeA.prev != null) {
-            c.m_nodeA.prev!!.next = c.m_nodeA.next
+        if (c.nodeA.prev != null) {
+            c.nodeA.prev!!.next = c.nodeA.next
         }
 
-        if (c.m_nodeA.next != null) {
-            c.m_nodeA.next!!.prev = c.m_nodeA.prev
+        if (c.nodeA.next != null) {
+            c.nodeA.next!!.prev = c.nodeA.prev
         }
 
-        if (c.m_nodeA == bodyA!!.m_contactList) {
-            bodyA.m_contactList = c.m_nodeA.next
+        if (c.nodeA == bodyA!!.contactList) {
+            bodyA.contactList = c.nodeA.next
         }
 
         // Remove from body 2
-        if (c.m_nodeB.prev != null) {
-            c.m_nodeB.prev!!.next = c.m_nodeB.next
+        if (c.nodeB.prev != null) {
+            c.nodeB.prev!!.next = c.nodeB.next
         }
 
-        if (c.m_nodeB.next != null) {
-            c.m_nodeB.next!!.prev = c.m_nodeB.prev
+        if (c.nodeB.next != null) {
+            c.nodeB.next!!.prev = c.nodeB.prev
         }
 
-        if (c.m_nodeB == bodyB!!.m_contactList) {
-            bodyB.m_contactList = c.m_nodeB.next
+        if (c.nodeB == bodyB!!.contactList) {
+            bodyB.contactList = c.nodeB.next
         }
 
         // Call the factory.
         pool.pushContact(c)
-        --m_contactCount
+        --contactCount
     }
 
     /**
@@ -216,61 +210,61 @@ class ContactManager(private val pool: World, var m_broadPhase: BroadPhase) : Pa
      */
     fun collide() {
         // Update awake contacts.
-        var c = m_contactList
+        var c = contactList
         while (c != null) {
-            val fixtureA = c.getFixtureA()
-            val fixtureB = c.getFixtureB()
-            val indexA = c.getChildIndexA()
-            val indexB = c.getChildIndexB()
-            val bodyA = fixtureA!!.getBody()
-            val bodyB = fixtureB!!.getBody()
+            val fixtureA = c.fixtureA
+            val fixtureB = c.fixtureB
+            val indexA = c.indexA
+            val indexB = c.indexB
+            val bodyA = fixtureA!!.body
+            val bodyB = fixtureB!!.body
 
             // is this contact flagged for filtering?
-            if (c.m_flags and Contact.FILTER_FLAG == Contact.FILTER_FLAG) {
+            if (c.flags and Contact.FILTER_FLAG == Contact.FILTER_FLAG) {
                 // Should these bodies collide?
                 if (bodyB!!.shouldCollide(bodyA!!) == false) {
                     val cNuke = c
-                    c = cNuke.getNext()
+                    c = cNuke.next
                     destroy(cNuke)
                     continue
                 }
 
                 // Check user filtering.
-                if (m_contactFilter != null && m_contactFilter!!.shouldCollide(fixtureA, fixtureB) == false) {
+                if (contactFilter != null && contactFilter!!.shouldCollide(fixtureA, fixtureB) == false) {
                     val cNuke = c
-                    c = cNuke.getNext()
+                    c = cNuke.next
                     destroy(cNuke)
                     continue
                 }
 
                 // Clear the filtering flag.
-                c.m_flags = c.m_flags and Contact.FILTER_FLAG.inv()
+                c.flags = c.flags and Contact.FILTER_FLAG.inv()
             }
 
-            val activeA = bodyA!!.isAwake && bodyA.m_type !== BodyType.STATIC
-            val activeB = bodyB!!.isAwake && bodyB.m_type !== BodyType.STATIC
+            val activeA = bodyA!!.isAwake && bodyA._type !== BodyType.STATIC
+            val activeB = bodyB!!.isAwake && bodyB._type !== BodyType.STATIC
 
             // At least one body must be awake and it must be dynamic or kinematic.
             if (activeA == false && activeB == false) {
-                c = c.getNext()
+                c = c.next
                 continue
             }
 
-            val proxyIdA = fixtureA.m_proxies!![indexA].proxyId
-            val proxyIdB = fixtureB.m_proxies!![indexB].proxyId
-            val overlap = m_broadPhase.testOverlap(proxyIdA, proxyIdB)
+            val proxyIdA = fixtureA.proxies!![indexA].proxyId
+            val proxyIdB = fixtureB.proxies!![indexB].proxyId
+            val overlap = broadPhase.testOverlap(proxyIdA, proxyIdB)
 
             // Here we destroy contacts that cease to overlap in the broad-phase.
             if (overlap == false) {
                 val cNuke = c
-                c = cNuke.getNext()
+                c = cNuke.next
                 destroy(cNuke)
                 continue
             }
 
             // The contact persists.
-            c.update(m_contactListener)
-            c = c.getNext()
+            c.update(contactListener)
+            c = c.next
         }
     }
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/Filter.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/Filter.kt
@@ -23,24 +23,22 @@
  */
 package org.jbox2d.dynamics
 
-// updated to rev 100
 /**
  * This holds contact filtering data.
  *
  * @author daniel
  */
 class Filter {
+
     /**
      * The collision category bits. Normally you would just set one bit.
      */
-
     var categoryBits: Int = 0x0001
 
     /**
      * The collision mask bits. This states the categories that this
      * shape would accept for collision.
      */
-
     var maskBits: Int = 0xFFFF
 
     /**
@@ -48,7 +46,6 @@ class Filter {
      * or always collide (positive). Zero means no collision group. Non-zero group
      * filtering always wins against the mask bits.
      */
-
     var groupIndex: Int = 0
 
     fun set(argOther: Filter) {

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/FixtureDef.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/FixtureDef.kt
@@ -33,6 +33,7 @@ import org.jbox2d.userdata.*
  * @author daniel
  */
 data class FixtureDef(
+
     /**
      * The shape, this must be set. The shape will be cloned, so you can create the shape on the
      * stack.

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/Profile.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/Profile.kt
@@ -27,38 +27,23 @@ import org.jbox2d.common.MathUtils
 
 class Profile {
 
-
     val step = ProfileEntry()
-
     val stepInit = ProfileEntry()
-
     val collide = ProfileEntry()
-
     val solveParticleSystem = ProfileEntry()
-
     val solve = ProfileEntry()
-
     val solveInit = ProfileEntry()
-
     val solveVelocity = ProfileEntry()
-
     val solvePosition = ProfileEntry()
-
     val broadphase = ProfileEntry()
-
     val solveTOI = ProfileEntry()
 
     class ProfileEntry {
-        internal var longAvg: Float = 0.toFloat()
-        internal var shortAvg: Float = 0.toFloat()
-        internal var min: Float = 0.toFloat()
-        internal var max: Float = 0.toFloat()
-        internal var accum: Float = 0.toFloat()
-
-        init {
-            min = Float.MAX_VALUE
-            max = -Float.MAX_VALUE
-        }
+        internal var longAvg: Float = 0f
+        internal var shortAvg: Float = 0f
+        internal var min: Float = Float.MAX_VALUE
+        internal var max: Float = -Float.MAX_VALUE
+        internal var accum: Float = 0f
 
         fun record(value: Float) {
             longAvg = longAvg * (1 - LONG_FRACTION) + value * LONG_FRACTION
@@ -99,9 +84,9 @@ class Profile {
     }
 
     companion object {
-        private val LONG_AVG_NUMS = 20
-        private val LONG_FRACTION = 1f / LONG_AVG_NUMS
-        private val SHORT_AVG_NUMS = 5
-        private val SHORT_FRACTION = 1f / SHORT_AVG_NUMS
+        private const val LONG_AVG_NUMS = 20
+        private const val LONG_FRACTION = 1f / LONG_AVG_NUMS
+        private const val SHORT_AVG_NUMS = 5
+        private const val SHORT_FRACTION = 1f / SHORT_AVG_NUMS
     }
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/TimeStep.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/TimeStep.kt
@@ -23,30 +23,23 @@
  */
 package org.jbox2d.dynamics
 
-//updated to rev 100
 /**
  * This is an internal structure.
  */
 class TimeStep {
 
     /** time step  */
-
-    var dt: Float = 0.toFloat()
+    var dt: Float = 0f
 
     /** inverse time step (0 if dt == 0).  */
+    var invDt: Float = 0f
 
-    var inv_dt: Float = 0.toFloat()
-
-    /** dt * inv_dt0  */
-
-    var dtRatio: Float = 0.toFloat()
-
+    /** dt * invDt0  */
+    var dtRatio: Float = 0f
 
     var velocityIterations: Int = 0
 
-
     var positionIterations: Int = 0
-
 
     var warmStarting: Boolean = false
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/WorldRefExt.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/WorldRefExt.kt
@@ -6,7 +6,7 @@ inline fun WorldRef.forEachBody(callback: (body: Body) -> Unit) {
     var node = world.bodyList
     while (node != null) {
         callback(node)
-        node = node.m_next
+        node = node.next
     }
 }
 
@@ -14,6 +14,6 @@ inline fun WorldRef.forEachJoint(callback: (joint: Joint) -> Unit) {
     var node = world.jointList
     while (node != null) {
         callback(node)
-        node = node.m_next
+        node = node.next
     }
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/contacts/ChainAndCircleContact.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/contacts/ChainAndCircleContact.kt
@@ -39,14 +39,13 @@ class ChainAndCircleContact(argPool: IWorldPool) : Contact(argPool) {
 
     override fun init(fA: Fixture, indexA: Int, fB: Fixture, indexB: Int) {
         super.init(fA, indexA, fB, indexB)
-        assert(m_fixtureA!!.type === ShapeType.CHAIN)
-        assert(m_fixtureB!!.type === ShapeType.CIRCLE)
+        assert(fixtureA!!.type === ShapeType.CHAIN)
+        assert(fixtureB!!.type === ShapeType.CIRCLE)
     }
 
     override fun evaluate(manifold: Manifold, xfA: Transform, xfB: Transform) {
-        val chain = m_fixtureA!!.m_shape as ChainShape
-        chain.getChildEdge(edge, m_indexA)
-        pool.collision.collideEdgeAndCircle(manifold, edge, xfA,
-                m_fixtureB!!.m_shape as CircleShape, xfB)
+        val chain = fixtureA!!.shape as ChainShape
+        chain.getChildEdge(edge, indexA)
+        pool.collision.collideEdgeAndCircle(manifold, edge, xfA, fixtureB!!.shape as CircleShape, xfB)
     }
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/contacts/ChainAndPolygonContact.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/contacts/ChainAndPolygonContact.kt
@@ -39,14 +39,13 @@ class ChainAndPolygonContact(argPool: IWorldPool) : Contact(argPool) {
 
     override fun init(fA: Fixture, indexA: Int, fB: Fixture, indexB: Int) {
         super.init(fA, indexA, fB, indexB)
-        assert(m_fixtureA!!.type === ShapeType.CHAIN)
-        assert(m_fixtureB!!.type === ShapeType.POLYGON)
+        assert(fixtureA!!.type === ShapeType.CHAIN)
+        assert(fixtureB!!.type === ShapeType.POLYGON)
     }
 
     override fun evaluate(manifold: Manifold, xfA: Transform, xfB: Transform) {
-        val chain = m_fixtureA!!.m_shape as ChainShape
-        chain.getChildEdge(edge, m_indexA)
-        pool.collision.collideEdgeAndPolygon(manifold, edge, xfA,
-                m_fixtureB!!.m_shape as PolygonShape, xfB)
+        val chain = fixtureA!!.shape as ChainShape
+        chain.getChildEdge(edge, indexA)
+        pool.collision.collideEdgeAndPolygon(manifold, edge, xfA, fixtureB!!.shape as PolygonShape, xfB)
     }
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/contacts/CircleContact.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/contacts/CircleContact.kt
@@ -35,12 +35,14 @@ class CircleContact(argPool: IWorldPool) : Contact(argPool) {
 
     fun init(fixtureA: Fixture, fixtureB: Fixture) {
         super.init(fixtureA, 0, fixtureB, 0)
-        assert(m_fixtureA!!.type === ShapeType.CIRCLE)
-        assert(m_fixtureB!!.type === ShapeType.CIRCLE)
+        assert(this.fixtureA!!.type === ShapeType.CIRCLE)
+        assert(this.fixtureB!!.type === ShapeType.CIRCLE)
     }
 
     override fun evaluate(manifold: Manifold, xfA: Transform, xfB: Transform) {
-        pool.collision.collideCircles(manifold, m_fixtureA!!.m_shape as CircleShape, xfA,
-                m_fixtureB!!.m_shape as CircleShape, xfB)
+        pool.collision.collideCircles(
+            manifold, fixtureA!!.shape as CircleShape, xfA,
+            fixtureB!!.shape as CircleShape, xfB
+        )
     }
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/contacts/Contact.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/contacts/Contact.kt
@@ -23,7 +23,6 @@
  */
 package org.jbox2d.dynamics.contacts
 
-
 import org.jbox2d.callbacks.ContactListener
 import org.jbox2d.collision.Manifold
 import org.jbox2d.collision.WorldManifold
@@ -39,102 +38,55 @@ import org.jbox2d.pooling.IWorldPool
  *
  * @author daniel
  */
-abstract class Contact protected constructor( protected val pool: IWorldPool) {
+abstract class Contact protected constructor(protected val pool: IWorldPool) {
 
-    var m_flags: Int = 0
+    var flags: Int = 0
 
     // World pool and list pointers.
-
-    var m_prev: Contact? = null
-    /**
-     * Get the next contact in the world's contact list.
-     *
-     * @return
-     */
-
-    var m_next: Contact? = null
-
-    fun getPrev() = m_prev
-    fun getNext() = m_next
+    var prev: Contact? = null
+    var next: Contact? = null
 
     // Nodes for connecting bodies.
+    var nodeA: ContactEdge = ContactEdge()
+    var nodeB: ContactEdge = ContactEdge()
 
-    var m_nodeA: ContactEdge = ContactEdge()
+    /** The first fixture in this contact. */
+    var fixtureA: Fixture? = null
 
-    var m_nodeB: ContactEdge = ContactEdge()
+    /** The second fixture in this contact. */
+    var fixtureB: Fixture? = null
 
-    /**
-     * Get the first fixture in this contact.
-     *
-     * @return
-     */
-
-    var m_fixtureA: Fixture? = null
-    /**
-     * Get the second fixture in this contact.
-     *
-     * @return
-     */
-
-    var m_fixtureB: Fixture? = null
-
-    fun getFixtureA() = m_fixtureA
-    fun getFixtureB() = m_fixtureB
-
-
-    var m_indexA: Int = 0
-
-    var m_indexB: Int = 0
-
-    fun getChildIndexA() = m_indexA
-    fun getChildIndexB() = m_indexB
+    var indexA: Int = 0
+    var indexB: Int = 0
 
     /**
-     * Get the contact manifold. Do not set the point count to zero. Instead call Disable.
+     * Get the contact manifold. Do not set the point count to zero. Instead call [disable].
      */
+    val manifold: Manifold = Manifold()
 
-    val m_manifold: Manifold = Manifold()
+    var toiCount: Float = 0f
+    var toi: Float = 0f
 
-    fun getManifold(): Manifold = m_manifold
+    var friction: Float = 0f
+    var restitution: Float = 0f
 
+    var tangentSpeed: Float = 0f
 
-    var m_toiCount: Float = 0.toFloat()
-
-    var m_toi: Float = 0.toFloat()
-
-
-    var m_friction: Float = 0.toFloat()
-
-    var m_restitution: Float = 0.toFloat()
-
-
-    var m_tangentSpeed: Float = 0.toFloat()
-
-    /**
-     * Is this contact touching
-     *
-     * @return
-     */
     val isTouching: Boolean
-        get() = m_flags and TOUCHING_FLAG == TOUCHING_FLAG
+        get() = flags and TOUCHING_FLAG == TOUCHING_FLAG
 
-    /**
-     * Has this contact been disabled?
-     *
-     * @return
-     */
     /**
      * Enable/disable this contact. This can be used inside the pre-solve contact listener. The
      * contact is only disabled for the current time step (or sub-step in continuous collisions).
-     *
-     * @param flag
      */
     var isEnabled: Boolean
-        get() = m_flags and ENABLED_FLAG == ENABLED_FLAG
-        set(flag) = if (flag) {
-            m_flags = m_flags or ENABLED_FLAG
-        } else {
-            m_flags = m_flags and ENABLED_FLAG.inv()
+        get() = flags and ENABLED_FLAG == ENABLED_FLAG
+        set(flag) {
+            flags = if (flag) {
+                flags or ENABLED_FLAG
+            } else {
+                flags and ENABLED_FLAG.inv()
+            }
         }
 
     // djm pooling
@@ -142,55 +94,54 @@ abstract class Contact protected constructor( protected val pool: IWorldPool) {
 
     /** initialization for pooling  */
     open fun init(fA: Fixture, indexA: Int, fB: Fixture, indexB: Int) {
-        m_flags = ENABLED_FLAG
+        flags = ENABLED_FLAG
 
-        m_fixtureA = fA
-        m_fixtureB = fB
+        fixtureA = fA
+        fixtureB = fB
 
-        m_indexA = indexA
-        m_indexB = indexB
+        this.indexA = indexA
+        this.indexB = indexB
 
-        m_manifold.pointCount = 0
+        manifold.pointCount = 0
 
-        m_prev = null
-        m_next = null
+        prev = null
+        next = null
 
-        m_nodeA!!.contact = null
-        m_nodeA!!.prev = null
-        m_nodeA!!.next = null
-        m_nodeA!!.other = null
+        nodeA.contact = null
+        nodeA.prev = null
+        nodeA.next = null
+        nodeA.other = null
 
-        m_nodeB!!.contact = null
-        m_nodeB!!.prev = null
-        m_nodeB!!.next = null
-        m_nodeB!!.other = null
+        nodeB.contact = null
+        nodeB.prev = null
+        nodeB.next = null
+        nodeB.other = null
 
-        m_toiCount = 0f
-        m_friction = Contact.mixFriction(fA.m_friction, fB.m_friction)
-        m_restitution = Contact.mixRestitution(fA.m_restitution, fB.m_restitution)
+        toiCount = 0f
+        friction = mixFriction(fA.friction, fB.friction)
+        restitution = mixRestitution(fA.restitution, fB.restitution)
 
-        m_tangentSpeed = 0f
+        tangentSpeed = 0f
     }
 
-    /**
-     * Get the world manifold.
-     */
     fun getWorldManifold(worldManifold: WorldManifold) {
-        val bodyA = m_fixtureA!!.m_body
-        val bodyB = m_fixtureB!!.m_body
-        val shapeA = m_fixtureA!!.m_shape
-        val shapeB = m_fixtureB!!.m_shape
+        val bodyA = fixtureA!!.body
+        val bodyB = fixtureB!!.body
+        val shapeA = fixtureA!!.shape
+        val shapeB = fixtureB!!.shape
 
-        worldManifold.initialize(m_manifold, bodyA!!.m_xf, shapeA!!.m_radius,
-                bodyB!!.m_xf, shapeB!!.m_radius)
+        worldManifold.initialize(
+            manifold, bodyA!!.xf, shapeA!!.radius,
+            bodyB!!.xf, shapeB!!.radius
+        )
     }
 
     fun resetFriction() {
-        m_friction = Contact.mixFriction(m_fixtureA!!.m_friction, m_fixtureB!!.m_friction)
+        friction = mixFriction(fixtureA!!.friction, fixtureB!!.friction)
     }
 
     fun resetRestitution() {
-        m_restitution = Contact.mixRestitution(m_fixtureA!!.m_restitution, m_fixtureB!!.m_restitution)
+        restitution = mixRestitution(fixtureA!!.restitution, fixtureB!!.restitution)
     }
 
     abstract fun evaluate(manifold: Manifold, xfA: Transform, xfB: Transform)
@@ -199,45 +150,45 @@ abstract class Contact protected constructor( protected val pool: IWorldPool) {
      * Flag this contact for filtering. Filtering will occur the next time step.
      */
     fun flagForFiltering() {
-        m_flags = m_flags or FILTER_FLAG
+        flags = flags or FILTER_FLAG
     }
 
     fun update(listener: ContactListener?) {
 
-        oldManifold.set(m_manifold)
+        oldManifold.set(manifold)
 
         // Re-enable this contact.
-        m_flags = m_flags or ENABLED_FLAG
+        flags = flags or ENABLED_FLAG
 
-        var touching = false
-        val wasTouching = m_flags and TOUCHING_FLAG == TOUCHING_FLAG
+        val touching: Boolean
+        val wasTouching = flags and TOUCHING_FLAG == TOUCHING_FLAG
 
-        val sensorA = m_fixtureA!!.isSensor
-        val sensorB = m_fixtureB!!.isSensor
+        val sensorA = fixtureA!!.isSensor
+        val sensorB = fixtureB!!.isSensor
         val sensor = sensorA || sensorB
 
-        val bodyA = m_fixtureA!!.m_body!!
-        val bodyB = m_fixtureB!!.m_body!!
-        val xfA = bodyA.m_xf
-        val xfB = bodyB.m_xf
+        val bodyA = fixtureA!!.body!!
+        val bodyB = fixtureB!!.body!!
+        val xfA = bodyA.xf
+        val xfB = bodyB.xf
         // log.debug("TransformA: "+xfA);
         // log.debug("TransformB: "+xfB);
 
         if (sensor) {
-            val shapeA = m_fixtureA!!.m_shape!!
-            val shapeB = m_fixtureB!!.m_shape!!
-            touching = pool.collision.testOverlap(shapeA, m_indexA, shapeB, m_indexB, xfA, xfB)
+            val shapeA = fixtureA!!.shape!!
+            val shapeB = fixtureB!!.shape!!
+            touching = pool.collision.testOverlap(shapeA, indexA, shapeB, indexB, xfA, xfB)
 
             // Sensors don't generate manifolds.
-            m_manifold.pointCount = 0
+            manifold.pointCount = 0
         } else {
-            evaluate(m_manifold, xfA, xfB)
-            touching = m_manifold.pointCount > 0
+            evaluate(manifold, xfA, xfB)
+            touching = manifold.pointCount > 0
 
             // Match old contact ids to new contact ids and copy the
             // stored impulses to warm start the solver.
-            for (i in 0 until m_manifold.pointCount) {
-                val mp2 = m_manifold.points[i]
+            for (i in 0 until manifold.pointCount) {
+                val mp2 = manifold.points[i]
                 mp2.normalImpulse = 0.0f
                 mp2.tangentImpulse = 0.0f
                 val id2 = mp2.id
@@ -254,65 +205,57 @@ abstract class Contact protected constructor( protected val pool: IWorldPool) {
             }
 
             if (touching != wasTouching) {
-                bodyA!!.isAwake = true
-                bodyB!!.isAwake = true
+                bodyA.isAwake = true
+                bodyB.isAwake = true
             }
         }
 
-        if (touching) {
-            m_flags = m_flags or TOUCHING_FLAG
+        flags = if (touching) {
+            flags or TOUCHING_FLAG
         } else {
-            m_flags = m_flags and TOUCHING_FLAG.inv()
+            flags and TOUCHING_FLAG.inv()
         }
 
-        if (listener == null) {
-            return
-        }
+        if (listener == null) return
 
-        if (wasTouching == false && touching == true) {
+        if (!wasTouching && touching) {
             listener.beginContact(this)
         }
 
-        if (wasTouching == true && touching == false) {
+        if (wasTouching && !touching) {
             listener.endContact(this)
         }
 
-        if (sensor == false && touching) {
+        if (!sensor && touching) {
             listener.preSolve(this, oldManifold)
         }
     }
 
     companion object {
 
-        // Flags stored in m_flags
+        // Flags stored in flags
+
         // Used when crawling contact graph when forming islands.
-
         val ISLAND_FLAG = 0x0001
+
         // Set when the shapes are touching.
-
         val TOUCHING_FLAG = 0x0002
+
         // This contact can be disabled (by user)
-
         val ENABLED_FLAG = 0x0004
+
         // This contact needs filtering because a fixture filter was changed.
-
         val FILTER_FLAG = 0x0008
+
         // This bullet contact had a TOI event
-
         val BULLET_HIT_FLAG = 0x0010
-
 
         val TOI_FLAG = 0x0020
 
         /**
-         * Friction mixing law. The idea is to allow either fixture to drive the restitution to zero. For
-         * example, anything slides on ice.
-         *
-         * @param friction1
-         * @param friction2
-         * @return
+         * Friction mixing law. The idea is to allow either fixture to drive the restitution to zero.
+         * For example, anything slides on ice.
          */
-
         fun mixFriction(friction1: Float, friction2: Float): Float {
             return MathUtils.sqrt(friction1 * friction2)
         }
@@ -320,12 +263,7 @@ abstract class Contact protected constructor( protected val pool: IWorldPool) {
         /**
          * Restitution mixing law. The idea is allow for anything to bounce off an inelastic surface. For
          * example, a superball bounces on anything.
-         *
-         * @param restitution1
-         * @param restitution2
-         * @return
          */
-
         fun mixRestitution(restitution1: Float, restitution2: Float): Float {
             return if (restitution1 > restitution2) restitution1 else restitution2
         }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/contacts/ContactCreator.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/contacts/ContactCreator.kt
@@ -26,7 +26,6 @@ package org.jbox2d.dynamics.contacts
 import org.jbox2d.dynamics.Fixture
 import org.jbox2d.pooling.IWorldPool
 
-// updated to rev 100
 interface ContactCreator {
 
     fun contactCreateFcn(argPool: IWorldPool, fixtureA: Fixture, fixtureB: Fixture): Contact

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/contacts/ContactEdge.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/contacts/ContactEdge.kt
@@ -34,27 +34,15 @@ import org.jbox2d.dynamics.Body
  */
 class ContactEdge {
 
-    /**
-     * provides quick access to the other body attached.
-     */
-
+    /** provides quick access to the other body attached. */
     var other: Body? = null
 
-    /**
-     * the contact
-     */
-
+    /** the contact */
     var contact: Contact? = null
 
-    /**
-     * the previous contact edge in the body's contact list
-     */
-
+    /** the previous contact edge in the body's contact list */
     var prev: ContactEdge? = null
 
-    /**
-     * the next contact edge in the body's contact list
-     */
-
+    /** the next contact edge in the body's contact list */
     var next: ContactEdge? = null
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/contacts/ContactPositionConstraint.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/contacts/ContactPositionConstraint.kt
@@ -29,7 +29,7 @@ import org.jbox2d.common.Vec2
 
 class ContactPositionConstraint {
 
-    internal var localPoints = Array<Vec2>(Settings.maxManifoldPoints) { Vec2() }
+    internal var localPoints = Array(Settings.maxManifoldPoints) { Vec2() }
 
     internal val localNormal = Vec2()
 

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/contacts/ContactVelocityConstraint.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/contacts/ContactVelocityConstraint.kt
@@ -29,50 +29,40 @@ import org.jbox2d.common.Vec2
 
 class ContactVelocityConstraint {
 
-    var points = Array<VelocityConstraintPoint>(Settings.maxManifoldPoints) { VelocityConstraintPoint() }
+    var points = Array(Settings.maxManifoldPoints) { VelocityConstraintPoint() }
 
     val normal = Vec2()
-
     val normalMass = Mat22()
 
     val K = Mat22()
 
     var indexA: Int = 0
-
     var indexB: Int = 0
 
-    var invMassA: Float = 0.toFloat()
+    var invMassA: Float = 0f
+    var invMassB: Float = 0f
 
-    var invMassB: Float = 0.toFloat()
+    var invIA: Float = 0f
+    var invIB: Float = 0f
 
-    var invIA: Float = 0.toFloat()
-
-    var invIB: Float = 0.toFloat()
-
-    var friction: Float = 0.toFloat()
-
-    var restitution: Float = 0.toFloat()
-
-    var tangentSpeed: Float = 0.toFloat()
+    var friction: Float = 0f
+    var restitution: Float = 0f
+    var tangentSpeed: Float = 0f
 
     var pointCount: Int = 0
-
     var contactIndex: Int = 0
 
     class VelocityConstraintPoint {
 
         val rA = Vec2()
-
         val rB = Vec2()
 
-        var normalImpulse: Float = 0.toFloat()
+        var normalImpulse: Float = 0f
+        var tangentImpulse: Float = 0f
 
-        var tangentImpulse: Float = 0.toFloat()
+        var normalMass: Float = 0f
+        var tangentMass: Float = 0f
 
-        var normalMass: Float = 0.toFloat()
-
-        var tangentMass: Float = 0.toFloat()
-
-        var velocityBias: Float = 0.toFloat()
+        var velocityBias: Float = 0f
     }
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/contacts/EdgeAndCircleContact.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/contacts/EdgeAndCircleContact.kt
@@ -36,12 +36,14 @@ class EdgeAndCircleContact(argPool: IWorldPool) : Contact(argPool) {
 
     override fun init(fA: Fixture, indexA: Int, fB: Fixture, indexB: Int) {
         super.init(fA, indexA, fB, indexB)
-        assert(m_fixtureA!!.type === ShapeType.EDGE)
-        assert(m_fixtureB!!.type === ShapeType.CIRCLE)
+        assert(fixtureA!!.type === ShapeType.EDGE)
+        assert(fixtureB!!.type === ShapeType.CIRCLE)
     }
 
     override fun evaluate(manifold: Manifold, xfA: Transform, xfB: Transform) {
-        pool.collision.collideEdgeAndCircle(manifold, m_fixtureA!!.m_shape as EdgeShape, xfA,
-                m_fixtureB!!.m_shape as CircleShape, xfB)
+        pool.collision.collideEdgeAndCircle(
+            manifold, fixtureA!!.shape as EdgeShape, xfA,
+            fixtureB!!.shape as CircleShape, xfB
+        )
     }
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/contacts/EdgeAndPolygonContact.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/contacts/EdgeAndPolygonContact.kt
@@ -36,12 +36,14 @@ class EdgeAndPolygonContact(argPool: IWorldPool) : Contact(argPool) {
 
     override fun init(fA: Fixture, indexA: Int, fB: Fixture, indexB: Int) {
         super.init(fA, indexA, fB, indexB)
-        assert(m_fixtureA!!.type === ShapeType.EDGE)
-        assert(m_fixtureB!!.type === ShapeType.POLYGON)
+        assert(fixtureA!!.type === ShapeType.EDGE)
+        assert(fixtureB!!.type === ShapeType.POLYGON)
     }
 
     override fun evaluate(manifold: Manifold, xfA: Transform, xfB: Transform) {
-        pool.collision.collideEdgeAndPolygon(manifold, m_fixtureA!!.m_shape as EdgeShape, xfA,
-                m_fixtureB!!.m_shape as PolygonShape, xfB)
+        pool.collision.collideEdgeAndPolygon(
+            manifold, fixtureA!!.shape as EdgeShape, xfA,
+            fixtureB!!.shape as PolygonShape, xfB
+        )
     }
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/contacts/PolygonAndCircleContact.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/contacts/PolygonAndCircleContact.kt
@@ -36,12 +36,14 @@ class PolygonAndCircleContact(argPool: IWorldPool) : Contact(argPool) {
 
     fun init(fixtureA: Fixture, fixtureB: Fixture) {
         super.init(fixtureA, 0, fixtureB, 0)
-        assert(m_fixtureA!!.type === ShapeType.POLYGON)
-        assert(m_fixtureB!!.type === ShapeType.CIRCLE)
+        assert(this.fixtureA!!.type === ShapeType.POLYGON)
+        assert(this.fixtureB!!.type === ShapeType.CIRCLE)
     }
 
     override fun evaluate(manifold: Manifold, xfA: Transform, xfB: Transform) {
-        pool.collision.collidePolygonAndCircle(manifold, m_fixtureA!!.m_shape as PolygonShape,
-                xfA, m_fixtureB!!.m_shape as CircleShape, xfB)
+        pool.collision.collidePolygonAndCircle(
+            manifold, fixtureA!!.shape as PolygonShape,
+            xfA, fixtureB!!.shape as CircleShape, xfB
+        )
     }
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/contacts/PolygonContact.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/contacts/PolygonContact.kt
@@ -35,12 +35,14 @@ class PolygonContact(argPool: IWorldPool) : Contact(argPool) {
 
     fun init(fixtureA: Fixture, fixtureB: Fixture) {
         super.init(fixtureA, 0, fixtureB, 0)
-        assert(m_fixtureA!!.type == ShapeType.POLYGON)
-        assert(m_fixtureB!!.type == ShapeType.POLYGON)
+        assert(this.fixtureA!!.type == ShapeType.POLYGON)
+        assert(this.fixtureB!!.type == ShapeType.POLYGON)
     }
 
     override fun evaluate(manifold: Manifold, xfA: Transform, xfB: Transform) {
-        pool.collision.collidePolygons(manifold, m_fixtureA!!.m_shape as PolygonShape, xfA,
-                m_fixtureB!!.m_shape as PolygonShape, xfB)
+        pool.collision.collidePolygons(
+            manifold, fixtureA!!.shape as PolygonShape, xfA,
+            fixtureB!!.shape as PolygonShape, xfB
+        )
     }
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/contacts/Position.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/contacts/Position.kt
@@ -29,5 +29,5 @@ class Position {
 
     val c = Vec2()
 
-    var a: Float = 0.toFloat()
+    var a: Float = 0f
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/contacts/PositionSolverManifold.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/contacts/PositionSolverManifold.kt
@@ -9,10 +9,8 @@ import org.jbox2d.internal.*
 internal class PositionSolverManifold {
 
     val normal = Vec2()
-
     val point = Vec2()
-
-    var separation: Float = 0.toFloat()
+    var separation: Float = 0f
 
     fun initialize(pc: ContactPositionConstraint, xfA: Transform, xfB: Transform, index: Int) {
         assert(pc.pointCount > 0)

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/contacts/Velocity.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/contacts/Velocity.kt
@@ -29,5 +29,5 @@ class Velocity {
 
     val v = Vec2()
 
-    var w: Float = 0.toFloat()
+    var w: Float = 0f
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/ConstantVolumeJointDef.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/ConstantVolumeJointDef.kt
@@ -24,7 +24,6 @@
 package org.jbox2d.dynamics.joints
 
 import org.jbox2d.dynamics.*
-import kotlin.jvm.*
 
 /**
  * Definition for a [ConstantVolumeJoint], which connects a group a bodies together so they
@@ -41,22 +40,18 @@ class ConstantVolumeJointDef : JointDef(JointType.CONSTANT_VOLUME) {
 
     init {
         collideConnected = false
-        frequencyHz = 0.0f
-        dampingRatio = 0.0f
     }
 
     /**
-     * Adds a body to the group
-     *
-     * @param argBody
+     * Adds a [body] to the group
      */
-    fun addBody(argBody: Body) {
-        bodies.add(argBody)
+    fun addBody(body: Body) {
+        bodies.add(body)
         if (bodies.size == 1) {
-            bodyA = argBody
+            bodyA = body
         }
         if (bodies.size == 2) {
-            bodyB = argBody
+            bodyB = body
         }
     }
 

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/DistanceJoint.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/DistanceJoint.kt
@@ -53,99 +53,78 @@ import org.jbox2d.common.Vec2
 import org.jbox2d.dynamics.SolverData
 import org.jbox2d.pooling.IWorldPool
 
-//C = norm(p2 - p1) - L
-//u = (p2 - p1) / norm(p2 - p1)
-//Cdot = dot(u, v2 + cross(w2, r2) - v1 - cross(w1, r1))
-//J = [-u -cross(r1, u) u cross(r2, u)]
-//K = J * invM * JT
-//= invMass1 + invI1 * cross(r1, u)^2 + invMass2 + invI2 * cross(r2, u)^2
-
 /**
  * A distance joint constrains two points on two bodies to remain at a fixed distance from each
  * other. You can view this as a massless, rigid rod.
  */
 class DistanceJoint(argWorld: IWorldPool, def: DistanceJointDef) : Joint(argWorld, def) {
 
-    var frequency: Float = 0.toFloat()
-    var dampingRatio: Float = 0.toFloat()
-    private var m_bias: Float = 0.toFloat()
+    var frequency: Float = def.frequencyHz
+    var dampingRatio: Float = def.dampingRatio
+    private var bias: Float = 0f
 
     // Solver shared
-    val localAnchorA: Vec2
-    val localAnchorB: Vec2
-    private var m_gamma: Float = 0.toFloat()
-    private var m_impulse: Float = 0.toFloat()
-    var length: Float = 0.toFloat()
+    val localAnchorA: Vec2 = def.localAnchorA.clone()
+    val localAnchorB: Vec2 = def.localAnchorB.clone()
+    private var gamma: Float = 0f
+    private var impulse: Float = 0f
+    var length: Float = def.length
 
     // Solver temp
-    private var m_indexA: Int = 0
-    private var m_indexB: Int = 0
-    private val m_u = Vec2()
-    private val m_rA = Vec2()
-    private val m_rB = Vec2()
-    private val m_localCenterA = Vec2()
-    private val m_localCenterB = Vec2()
-    private var m_invMassA: Float = 0.toFloat()
-    private var m_invMassB: Float = 0.toFloat()
-    private var m_invIA: Float = 0.toFloat()
-    private var m_invIB: Float = 0.toFloat()
-    private var m_mass: Float = 0.toFloat()
+    private var indexA: Int = 0
+    private var indexB: Int = 0
+    private val u = Vec2()
+    private val rA = Vec2()
+    private val rB = Vec2()
+    private val localCenterA = Vec2()
+    private val localCenterB = Vec2()
+    private var invMassA: Float = 0f
+    private var invMassB: Float = 0f
+    private var invIA: Float = 0f
+    private var invIB: Float = 0f
+    private var mass: Float = 0f
 
-    init {
-        localAnchorA = def.localAnchorA.clone()
-        localAnchorB = def.localAnchorB.clone()
-        length = def.length
-        m_impulse = 0.0f
-        frequency = def.frequencyHz
-        dampingRatio = def.dampingRatio
-        m_gamma = 0.0f
-        m_bias = 0.0f
+    override fun getAnchorA(out: Vec2) {
+        bodyA!!.getWorldPointToOut(localAnchorA, out)
     }
 
-    override fun getAnchorA(argOut: Vec2) {
-        m_bodyA!!.getWorldPointToOut(localAnchorA, argOut)
-    }
-
-    override fun getAnchorB(argOut: Vec2) {
-        m_bodyB!!.getWorldPointToOut(localAnchorB, argOut)
+    override fun getAnchorB(out: Vec2) {
+        bodyB!!.getWorldPointToOut(localAnchorB, out)
     }
 
     /**
      * Get the reaction force given the inverse time step. Unit is N.
      */
-    override fun getReactionForce(inv_dt: Float, argOut: Vec2) {
-        argOut.x = m_impulse * m_u.x * inv_dt
-        argOut.y = m_impulse * m_u.y * inv_dt
+    override fun getReactionForce(invDt: Float, out: Vec2) {
+        out.x = impulse * u.x * invDt
+        out.y = impulse * u.y * invDt
     }
 
     /**
      * Get the reaction torque given the inverse time step. Unit is N*m. This is always zero for a
      * distance joint.
      */
-    override fun getReactionTorque(inv_dt: Float): Float {
-        return 0.0f
-    }
+    override fun getReactionTorque(invDt: Float) = 0f
 
     override fun initVelocityConstraints(data: SolverData) {
+        indexA = bodyA!!.islandIndex
+        indexB = bodyB!!.islandIndex
+        localCenterA.set(bodyA!!.sweep.localCenter)
+        localCenterB.set(bodyB!!.sweep.localCenter)
+        invMassA = bodyA!!.invMass
+        invMassB = bodyB!!.invMass
+        invIA = bodyA!!.invI
+        invIB = bodyB!!.invI
 
-        m_indexA = m_bodyA!!.m_islandIndex
-        m_indexB = m_bodyB!!.m_islandIndex
-        m_localCenterA.set(m_bodyA!!.m_sweep.localCenter)
-        m_localCenterB.set(m_bodyB!!.m_sweep.localCenter)
-        m_invMassA = m_bodyA!!.m_invMass
-        m_invMassB = m_bodyB!!.m_invMass
-        m_invIA = m_bodyA!!.m_invI
-        m_invIB = m_bodyB!!.m_invI
+        val cA = data.positions!![indexA].c
+        val aA = data.positions!![indexA].a
+        val vA = data.velocities!![indexA].v
+        var wA = data.velocities!![indexA].w
 
-        val cA = data.positions!![m_indexA].c
-        val aA = data.positions!![m_indexA].a
-        val vA = data.velocities!![m_indexA].v
-        var wA = data.velocities!![m_indexA].w
-
-        val cB = data.positions!![m_indexB].c
-        val aB = data.positions!![m_indexB].a
-        val vB = data.velocities!![m_indexB].v
-        var wB = data.velocities!![m_indexB].w
+        val cB = data.positions!![indexB].c
+        val aB = data.positions!![indexB].a
+        val vB = data.velocities!![indexB].v
+        var wB = data.velocities!![indexB].w
 
         val qA = pool.popRot()
         val qB = pool.popRot()
@@ -154,28 +133,27 @@ class DistanceJoint(argWorld: IWorldPool, def: DistanceJointDef) : Joint(argWorl
         qB.setRadians(aB)
 
         // use m_u as temporary variable
-        Rot.mulToOutUnsafe(qA, m_u.set(localAnchorA).subLocal(m_localCenterA), m_rA)
-        Rot.mulToOutUnsafe(qB, m_u.set(localAnchorB).subLocal(m_localCenterB), m_rB)
-        m_u.set(cB).addLocal(m_rB).subLocal(cA).subLocal(m_rA)
+        Rot.mulToOutUnsafe(qA, u.set(localAnchorA).subLocal(localCenterA), rA)
+        Rot.mulToOutUnsafe(qB, u.set(localAnchorB).subLocal(localCenterB), rB)
+        u.set(cB).addLocal(rB).subLocal(cA).subLocal(rA)
 
         pool.pushRot(2)
 
         // Handle singularity.
-        val length = m_u.length()
+        val length = u.length()
         if (length > Settings.linearSlop) {
-            m_u.x *= 1.0f / length
-            m_u.y *= 1.0f / length
+            u.x *= 1.0f / length
+            u.y *= 1.0f / length
         } else {
-            m_u.set(0.0f, 0.0f)
+            u.set(0.0f, 0.0f)
         }
 
-
-        val crAu = Vec2.cross(m_rA, m_u)
-        val crBu = Vec2.cross(m_rB, m_u)
-        var invMass = m_invMassA + m_invIA * crAu * crAu + m_invMassB + m_invIB * crBu * crBu
+        val crAu = Vec2.cross(rA, u)
+        val crBu = Vec2.cross(rB, u)
+        var invMass = invMassA + invIA * crAu * crAu + invMassB + invIB * crBu * crBu
 
         // Compute the effective mass matrix.
-        m_mass = if (invMass != 0.0f) 1.0f / invMass else 0.0f
+        mass = if (invMass != 0.0f) 1.0f / invMass else 0.0f
 
         if (frequency > 0.0f) {
             val C = length - this.length
@@ -184,107 +162,99 @@ class DistanceJoint(argWorld: IWorldPool, def: DistanceJointDef) : Joint(argWorl
             val omega = 2.0f * MathUtils.PI * frequency
 
             // Damping coefficient
-            val d = 2.0f * m_mass * dampingRatio * omega
+            val d = 2.0f * mass * dampingRatio * omega
 
             // Spring stiffness
-            val k = m_mass * omega * omega
+            val k = mass * omega * omega
 
             // magic formulas
             val h = data.step!!.dt
-            m_gamma = h * (d + h * k)
-            m_gamma = if (m_gamma != 0.0f) 1.0f / m_gamma else 0.0f
-            m_bias = C * h * k * m_gamma
+            gamma = h * (d + h * k)
+            gamma = if (gamma != 0.0f) 1.0f / gamma else 0.0f
+            bias = C * h * k * gamma
 
-            invMass += m_gamma
-            m_mass = if (invMass != 0.0f) 1.0f / invMass else 0.0f
+            invMass += gamma
+            mass = if (invMass != 0.0f) 1.0f / invMass else 0.0f
         } else {
-            m_gamma = 0.0f
-            m_bias = 0.0f
+            gamma = 0.0f
+            bias = 0.0f
         }
         if (data.step!!.warmStarting) {
-
             // Scale the impulse to support a variable time step.
-            m_impulse *= data.step!!.dtRatio
+            impulse *= data.step!!.dtRatio
 
             val P = pool.popVec2()
-            P.set(m_u).mulLocal(m_impulse)
+            P.set(u).mulLocal(impulse)
 
-            vA.x -= m_invMassA * P.x
-            vA.y -= m_invMassA * P.y
-            wA -= m_invIA * Vec2.cross(m_rA, P)
+            vA.x -= invMassA * P.x
+            vA.y -= invMassA * P.y
+            wA -= invIA * Vec2.cross(rA, P)
 
-            vB.x += m_invMassB * P.x
-            vB.y += m_invMassB * P.y
-            wB += m_invIB * Vec2.cross(m_rB, P)
+            vB.x += invMassB * P.x
+            vB.y += invMassB * P.y
+            wB += invIB * Vec2.cross(rB, P)
 
             pool.pushVec2(1)
         } else {
-            m_impulse = 0.0f
+            impulse = 0.0f
         }
-        //    data.velocities[m_indexA].v.set(vA);
-        data.velocities!![m_indexA].w = wA
-        //    data.velocities[m_indexB].v.set(vB);
-        data.velocities!![m_indexB].w = wB
+        data.velocities!![indexA].w = wA
+        data.velocities!![indexB].w = wB
     }
 
     override fun solveVelocityConstraints(data: SolverData) {
-        val vA = data.velocities!![m_indexA].v
-        var wA = data.velocities!![m_indexA].w
-        val vB = data.velocities!![m_indexB].v
-        var wB = data.velocities!![m_indexB].w
+        val vA = data.velocities!![indexA].v
+        var wA = data.velocities!![indexA].w
+        val vB = data.velocities!![indexB].v
+        var wB = data.velocities!![indexB].w
 
         val vpA = pool.popVec2()
         val vpB = pool.popVec2()
 
-        // Cdot = dot(u, v + cross(w, r))
-        Vec2.crossToOutUnsafe(wA, m_rA, vpA)
+        Vec2.crossToOutUnsafe(wA, rA, vpA)
         vpA.addLocal(vA)
-        Vec2.crossToOutUnsafe(wB, m_rB, vpB)
+        Vec2.crossToOutUnsafe(wB, rB, vpB)
         vpB.addLocal(vB)
-        val Cdot = Vec2.dot(m_u, vpB.subLocal(vpA))
+        val Cdot = Vec2.dot(u, vpB.subLocal(vpA))
 
-        val impulse = -m_mass * (Cdot + m_bias + m_gamma * m_impulse)
-        m_impulse += impulse
+        val impulse = -mass * (Cdot + bias + gamma * impulse)
+        this.impulse += impulse
 
 
-        val Px = impulse * m_u.x
-        val Py = impulse * m_u.y
+        val Px = impulse * u.x
+        val Py = impulse * u.y
 
-        vA.x -= m_invMassA * Px
-        vA.y -= m_invMassA * Py
-        wA -= m_invIA * (m_rA.x * Py - m_rA.y * Px)
-        vB.x += m_invMassB * Px
-        vB.y += m_invMassB * Py
-        wB += m_invIB * (m_rB.x * Py - m_rB.y * Px)
+        vA.x -= invMassA * Px
+        vA.y -= invMassA * Py
+        wA -= invIA * (rA.x * Py - rA.y * Px)
+        vB.x += invMassB * Px
+        vB.y += invMassB * Py
+        wB += invIB * (rB.x * Py - rB.y * Px)
 
-        //    data.velocities[m_indexA].v.set(vA);
-        data.velocities!![m_indexA].w = wA
-        //    data.velocities[m_indexB].v.set(vB);
-        data.velocities!![m_indexB].w = wB
+        data.velocities!![indexA].w = wA
+        data.velocities!![indexB].w = wB
 
         pool.pushVec2(2)
     }
 
     override fun solvePositionConstraints(data: SolverData): Boolean {
-        if (frequency > 0.0f) {
-            return true
-        }
+        if (frequency > 0.0f) return true
         val qA = pool.popRot()
         val qB = pool.popRot()
         val rA = pool.popVec2()
         val rB = pool.popVec2()
         val u = pool.popVec2()
 
-        val cA = data.positions!![m_indexA].c
-        var aA = data.positions!![m_indexA].a
-        val cB = data.positions!![m_indexB].c
-        var aB = data.positions!![m_indexB].a
+        val cA = data.positions!![indexA].c
+        var aA = data.positions!![indexA].a
+        val cB = data.positions!![indexB].c
+        var aB = data.positions!![indexB].a
 
         qA.setRadians(aA)
         qB.setRadians(aB)
 
-        Rot.mulToOutUnsafe(qA, u.set(localAnchorA).subLocal(m_localCenterA), rA)
-        Rot.mulToOutUnsafe(qB, u.set(localAnchorB).subLocal(m_localCenterB), rB)
+        Rot.mulToOutUnsafe(qA, u.set(localAnchorA).subLocal(localCenterA), rA)
+        Rot.mulToOutUnsafe(qB, u.set(localAnchorB).subLocal(localCenterB), rB)
         u.set(cB).addLocal(rB).subLocal(cA).subLocal(rA)
 
 
@@ -292,21 +262,19 @@ class DistanceJoint(argWorld: IWorldPool, def: DistanceJointDef) : Joint(argWorl
         var C = length - this.length
         C = MathUtils.clamp(C, -Settings.maxLinearCorrection, Settings.maxLinearCorrection)
 
-        val impulse = -m_mass * C
+        val impulse = -mass * C
         val Px = impulse * u.x
         val Py = impulse * u.y
 
-        cA.x -= m_invMassA * Px
-        cA.y -= m_invMassA * Py
-        aA -= m_invIA * (rA.x * Py - rA.y * Px)
-        cB.x += m_invMassB * Px
-        cB.y += m_invMassB * Py
-        aB += m_invIB * (rB.x * Py - rB.y * Px)
+        cA.x -= invMassA * Px
+        cA.y -= invMassA * Py
+        aA -= invIA * (rA.x * Py - rA.y * Px)
+        cB.x += invMassB * Px
+        cB.y += invMassB * Py
+        aB += invIB * (rB.x * Py - rB.y * Px)
 
-        //    data.positions[m_indexA].c.set(cA);
-        data.positions!![m_indexA].a = aA
-        //    data.positions[m_indexB].c.set(cB);
-        data.positions!![m_indexB].a = aB
+        data.positions!![indexA].a = aA
+        data.positions!![indexB].a = aB
 
         pool.pushVec2(3)
         pool.pushRot(2)

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/DistanceJointDef.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/DistanceJointDef.kt
@@ -43,13 +43,10 @@
  * misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  */
-
 package org.jbox2d.dynamics.joints
 
 import org.jbox2d.common.Vec2
 import org.jbox2d.dynamics.Body
-
-//Updated to rev 56->130->142 of b2DistanceJoint.cpp/.h
 
 /**
  * Distance joint definition. This requires defining an anchor point on both bodies and the non-zero
@@ -59,28 +56,20 @@ import org.jbox2d.dynamics.Body
  * @warning Do not use a zero or short length.
  */
 class DistanceJointDef : JointDef(JointType.DISTANCE) {
-    /** The local anchor point relative to body1's origin.  */
 
+    /** The local anchor point relative to body1's origin.  */
     val localAnchorA: Vec2 = Vec2(0.0f, 0.0f)
 
     /** The local anchor point relative to body2's origin.  */
-
     val localAnchorB: Vec2 = Vec2(0.0f, 0.0f)
 
     /** The equilibrium length between the anchor points.  */
-
     var length: Float = 1f
 
-    /**
-     * The mass-spring-damper frequency in Hertz.
-     */
-
+    /** The mass-spring-damper frequency in Hertz. */
     var frequencyHz: Float = 0f
 
-    /**
-     * The damping ratio. 0 = no damping, 1 = critical damping.
-     */
-
+    /** The damping ratio. 0 = no damping, 1 = critical damping. */
     var dampingRatio: Float = 0f
 
     /**

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/FrictionJointDef.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/FrictionJointDef.kt
@@ -36,29 +36,24 @@ import org.jbox2d.dynamics.Body
  */
 class FrictionJointDef : JointDef(JointType.FRICTION) {
 
-
     /**
      * The local anchor point relative to bodyA's origin.
      */
-
     val localAnchorA: Vec2 = Vec2()
 
     /**
      * The local anchor point relative to bodyB's origin.
      */
-
     val localAnchorB: Vec2 = Vec2()
 
     /**
      * The maximum friction force in N.
      */
-
     var maxForce: Float = 0f
 
     /**
      * The maximum friction torque in N-m.
      */
-
     var maxTorque: Float = 0f
 
     /**

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/GearJoint.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/GearJoint.kt
@@ -34,25 +34,6 @@ import org.jbox2d.dynamics.SolverData
 import org.jbox2d.internal.*
 import org.jbox2d.pooling.IWorldPool
 
-//Gear Joint:
-//C0 = (coordinate1 + ratio * coordinate2)_initial
-//C = (coordinate1 + ratio * coordinate2) - C0 = 0
-//J = [J1 ratio * J2]
-//K = J * invM * JT
-//= J1 * invM1 * J1T + ratio * ratio * J2 * invM2 * J2T
-//
-//Revolute:
-//coordinate = rotation
-//Cdot = angularVelocity
-//J = [0 0 1]
-//K = J * invM * JT = invI
-//
-//Prismatic:
-//coordinate = dot(p - pg, ug)
-//Cdot = dot(v + cross(w, r), ug)
-//J = [ug cross(r, ug)]
-//K = J * invM * JT = invMass + invI * cross(r, ug)^2
-
 /**
  * A gear joint is used to connect two joints together. Either joint can be a revolute or prismatic
  * joint. You specify a gear ratio to bind the motions together: coordinate1 + ratio * coordinate2 =
@@ -66,204 +47,201 @@ import org.jbox2d.pooling.IWorldPool
  */
 class GearJoint(argWorldPool: IWorldPool, def: GearJointDef) : Joint(argWorldPool, def) {
 
-    val joint1: Joint? = def.joint1
+    val joint1: Joint = def.joint1!!
+    val joint2: Joint = def.joint2!!
 
-    val joint2: Joint? = def.joint2
+    private val typeA: JointType = joint1.type
+    private val typeB: JointType = joint2.type
 
-    private val m_typeA: JointType
-    private val m_typeB: JointType
+    init {
+        assert(typeA === JointType.REVOLUTE || typeA === JointType.PRISMATIC)
+        assert(typeB === JointType.REVOLUTE || typeB === JointType.PRISMATIC)
+    }
 
     // Body A is connected to body C
     // Body B is connected to body D
-    private val m_bodyC: Body
-    private val m_bodyD: Body
+    private val bodyC: Body
+    private val bodyD: Body
 
     // Solver shared
-    private val m_localAnchorA = Vec2()
-    private val m_localAnchorB = Vec2()
-    private val m_localAnchorC = Vec2()
-    private val m_localAnchorD = Vec2()
+    private val localAnchorA = Vec2()
+    private val localAnchorB = Vec2()
+    private val localAnchorC = Vec2()
+    private val localAnchorD = Vec2()
 
-    private val m_localAxisC = Vec2()
-    private val m_localAxisD = Vec2()
+    private val localAxisC = Vec2()
+    private val localAxisD = Vec2()
 
-    private var m_referenceAngleA: Float = 0.toFloat()
-    private var m_referenceAngleB: Float = 0.toFloat()
+    private var referenceAngleA: Float = 0f
+    private var referenceAngleB: Float = 0f
 
-    private val m_constant: Float
+    private val constant: Float
 
-    var ratio: Float = 0.toFloat()
+    var ratio: Float = 0f
 
-    private var m_impulse: Float = 0.toFloat()
+    private var impulse: Float = 0f
 
     // Solver temp
-    private var m_indexA: Int = 0
-    private var m_indexB: Int = 0
-    private var m_indexC: Int = 0
-    private var m_indexD: Int = 0
-    private val m_lcA = Vec2()
-    private val m_lcB = Vec2()
-    private val m_lcC = Vec2()
-    private val m_lcD = Vec2()
-    private var m_mA: Float = 0.toFloat()
-    private var m_mB: Float = 0.toFloat()
-    private var m_mC: Float = 0.toFloat()
-    private var m_mD: Float = 0.toFloat()
-    private var m_iA: Float = 0.toFloat()
-    private var m_iB: Float = 0.toFloat()
-    private var m_iC: Float = 0.toFloat()
-    private var m_iD: Float = 0.toFloat()
-    private val m_JvAC = Vec2()
-    private val m_JvBD = Vec2()
-    private var m_JwA: Float = 0.toFloat()
-    private var m_JwB: Float = 0.toFloat()
-    private var m_JwC: Float = 0.toFloat()
-    private var m_JwD: Float = 0.toFloat()
-    private var m_mass: Float = 0.toFloat()
+    private var indexA: Int = 0
+    private var indexB: Int = 0
+    private var indexC: Int = 0
+    private var indexD: Int = 0
+    private val lcA = Vec2()
+    private val lcB = Vec2()
+    private val lcC = Vec2()
+    private val lcD = Vec2()
+    private var mA: Float = 0f
+    private var mB: Float = 0f
+    private var mC: Float = 0f
+    private var mD: Float = 0f
+    private var iA: Float = 0f
+    private var iB: Float = 0f
+    private var iC: Float = 0f
+    private var iD: Float = 0f
+    private val JvAC = Vec2()
+    private val JvBD = Vec2()
+    private var JwA: Float = 0f
+    private var JwB: Float = 0f
+    private var JwC: Float = 0f
+    private var JwD: Float = 0f
+    private var mass: Float = 0f
 
     init {
-
-        m_typeA = joint1!!._type
-        m_typeB = joint2!!._type
-
-        assert(m_typeA === JointType.REVOLUTE || m_typeA === JointType.PRISMATIC)
-        assert(m_typeB === JointType.REVOLUTE || m_typeB === JointType.PRISMATIC)
-
         val coordinateA: Float
         val coordinateB: Float
 
         // TODO_ERIN there might be some problem with the joint edges in Joint.
 
-        m_bodyC = joint1.m_bodyA!!
-        m_bodyA = joint1.m_bodyB
+        bodyC = joint1.bodyA!!
+        bodyA = joint1.bodyB
 
         // Get geometry of joint1
-        val xfA = m_bodyA!!.m_xf
-        val aA = m_bodyA!!.m_sweep.a
-        val xfC = m_bodyC.m_xf
-        val aC = m_bodyC.m_sweep.a
+        val xfA = bodyA!!.xf
+        val aA = bodyA!!.sweep.a
+        val xfC = bodyC.xf
+        val aC = bodyC.sweep.a
 
-        if (m_typeA === JointType.REVOLUTE) {
-            val revolute = def.joint1 as RevoluteJoint?
-            m_localAnchorC.set(revolute!!.m_localAnchorA)
-            m_localAnchorA.set(revolute.m_localAnchorB)
-            m_referenceAngleA = revolute.m_referenceAngleRadians
-            m_localAxisC.setZero()
+        if (typeA === JointType.REVOLUTE) {
+            val revolute = def.joint1 as RevoluteJoint
+            localAnchorC.set(revolute.localAnchorA)
+            localAnchorA.set(revolute.localAnchorB)
+            referenceAngleA = revolute.referenceAngleRadians
+            localAxisC.setZero()
 
-            coordinateA = aA - aC - m_referenceAngleA
+            coordinateA = aA - aC - referenceAngleA
         } else {
             val pA = pool.popVec2()
             val temp = pool.popVec2()
-            val prismatic = def.joint1 as PrismaticJoint?
-            m_localAnchorC.set(prismatic!!.m_localAnchorA)
-            m_localAnchorA.set(prismatic.m_localAnchorB)
-            m_referenceAngleA = prismatic.m_referenceAngleRadians
-            m_localAxisC.set(prismatic.m_localXAxisA)
+            val prismatic = def.joint1 as PrismaticJoint
+            localAnchorC.set(prismatic.localAnchorA)
+            localAnchorA.set(prismatic.localAnchorB)
+            referenceAngleA = prismatic.referenceAngleRadians
+            localAxisC.set(prismatic.localXAxisA)
 
-            val pC = m_localAnchorC
-            Rot.mulToOutUnsafe(xfA.q, m_localAnchorA, temp)
+            val pC = localAnchorC
+            Rot.mulToOutUnsafe(xfA.q, localAnchorA, temp)
             temp.addLocal(xfA.p).subLocal(xfC.p)
             Rot.mulTransUnsafe(xfC.q, temp, pA)
-            coordinateA = Vec2.dot(pA.subLocal(pC), m_localAxisC)
+            coordinateA = Vec2.dot(pA.subLocal(pC), localAxisC)
             pool.pushVec2(2)
         }
 
-        m_bodyD = joint2.m_bodyA!!
-        m_bodyB = joint2.m_bodyB
+        bodyD = joint2.bodyA!!
+        bodyB = joint2.bodyB
 
         // Get geometry of joint2
-        val xfB = m_bodyB!!.m_xf
-        val aB = m_bodyB!!.m_sweep.a
-        val xfD = m_bodyD.m_xf
-        val aD = m_bodyD.m_sweep.a
+        val xfB = bodyB!!.xf
+        val aB = bodyB!!.sweep.a
+        val xfD = bodyD.xf
+        val aD = bodyD.sweep.a
 
-        if (m_typeB === JointType.REVOLUTE) {
-            val revolute = def.joint2 as RevoluteJoint?
-            m_localAnchorD.set(revolute!!.m_localAnchorA)
-            m_localAnchorB.set(revolute.m_localAnchorB)
-            m_referenceAngleB = revolute.m_referenceAngleRadians
-            m_localAxisD.setZero()
+        if (typeB === JointType.REVOLUTE) {
+            val revolute = def.joint2 as RevoluteJoint
+            localAnchorD.set(revolute.localAnchorA)
+            localAnchorB.set(revolute.localAnchorB)
+            referenceAngleB = revolute.referenceAngleRadians
+            localAxisD.setZero()
 
-            coordinateB = aB - aD - m_referenceAngleB
+            coordinateB = aB - aD - referenceAngleB
         } else {
             val pB = pool.popVec2()
             val temp = pool.popVec2()
-            val prismatic = def.joint2 as PrismaticJoint?
-            m_localAnchorD.set(prismatic!!.m_localAnchorA)
-            m_localAnchorB.set(prismatic.m_localAnchorB)
-            m_referenceAngleB = prismatic.m_referenceAngleRadians
-            m_localAxisD.set(prismatic.m_localXAxisA)
+            val prismatic = def.joint2 as PrismaticJoint
+            localAnchorD.set(prismatic.localAnchorA)
+            localAnchorB.set(prismatic.localAnchorB)
+            referenceAngleB = prismatic.referenceAngleRadians
+            localAxisD.set(prismatic.localXAxisA)
 
-            val pD = m_localAnchorD
-            Rot.mulToOutUnsafe(xfB.q, m_localAnchorB, temp)
+            val pD = localAnchorD
+            Rot.mulToOutUnsafe(xfB.q, localAnchorB, temp)
             temp.addLocal(xfB.p).subLocal(xfD.p)
             Rot.mulTransUnsafe(xfD.q, temp, pB)
-            coordinateB = Vec2.dot(pB.subLocal(pD), m_localAxisD)
+            coordinateB = Vec2.dot(pB.subLocal(pD), localAxisD)
             pool.pushVec2(2)
         }
 
         ratio = def.ratio
 
-        m_constant = coordinateA + ratio * coordinateB
+        constant = coordinateA + ratio * coordinateB
 
-        m_impulse = 0.0f
+        impulse = 0f
     }
 
-    override fun getAnchorA(argOut: Vec2) {
-        m_bodyA!!.getWorldPointToOut(m_localAnchorA, argOut)
+    override fun getAnchorA(out: Vec2) {
+        bodyA!!.getWorldPointToOut(localAnchorA, out)
     }
 
-    override fun getAnchorB(argOut: Vec2) {
-        m_bodyB!!.getWorldPointToOut(m_localAnchorB, argOut)
+    override fun getAnchorB(out: Vec2) {
+        bodyB!!.getWorldPointToOut(localAnchorB, out)
     }
 
-    override fun getReactionForce(inv_dt: Float, argOut: Vec2) {
-        argOut.set(m_JvAC).mulLocal(m_impulse)
-        argOut.mulLocal(inv_dt)
+    override fun getReactionForce(invDt: Float, out: Vec2) {
+        out.set(JvAC).mulLocal(impulse)
+        out.mulLocal(invDt)
     }
 
-    override fun getReactionTorque(inv_dt: Float): Float {
-        val L = m_impulse * m_JwA
-        return inv_dt * L
+    override fun getReactionTorque(invDt: Float): Float {
+        val L = impulse * JwA
+        return invDt * L
     }
 
     override fun initVelocityConstraints(data: SolverData) {
-        m_indexA = m_bodyA!!.m_islandIndex
-        m_indexB = m_bodyB!!.m_islandIndex
-        m_indexC = m_bodyC.m_islandIndex
-        m_indexD = m_bodyD.m_islandIndex
-        m_lcA.set(m_bodyA!!.m_sweep.localCenter)
-        m_lcB.set(m_bodyB!!.m_sweep.localCenter)
-        m_lcC.set(m_bodyC.m_sweep.localCenter)
-        m_lcD.set(m_bodyD.m_sweep.localCenter)
-        m_mA = m_bodyA!!.m_invMass
-        m_mB = m_bodyB!!.m_invMass
-        m_mC = m_bodyC.m_invMass
-        m_mD = m_bodyD.m_invMass
-        m_iA = m_bodyA!!.m_invI
-        m_iB = m_bodyB!!.m_invI
-        m_iC = m_bodyC.m_invI
-        m_iD = m_bodyD.m_invI
+        indexA = bodyA!!.islandIndex
+        indexB = bodyB!!.islandIndex
+        indexC = bodyC.islandIndex
+        indexD = bodyD.islandIndex
+        lcA.set(bodyA!!.sweep.localCenter)
+        lcB.set(bodyB!!.sweep.localCenter)
+        lcC.set(bodyC.sweep.localCenter)
+        lcD.set(bodyD.sweep.localCenter)
+        mA = bodyA!!.invMass
+        mB = bodyB!!.invMass
+        mC = bodyC.invMass
+        mD = bodyD.invMass
+        iA = bodyA!!.invI
+        iB = bodyB!!.invI
+        iC = bodyC.invI
+        iD = bodyD.invI
 
         // Vec2 cA = data.positions[m_indexA].c;
-        val aA = data.positions!![m_indexA].a
-        val vA = data.velocities!![m_indexA].v
-        var wA = data.velocities!![m_indexA].w
+        val aA = data.positions!![indexA].a
+        val vA = data.velocities!![indexA].v
+        var wA = data.velocities!![indexA].w
 
         // Vec2 cB = data.positions[m_indexB].c;
-        val aB = data.positions!![m_indexB].a
-        val vB = data.velocities!![m_indexB].v
-        var wB = data.velocities!![m_indexB].w
+        val aB = data.positions!![indexB].a
+        val vB = data.velocities!![indexB].v
+        var wB = data.velocities!![indexB].w
 
         // Vec2 cC = data.positions[m_indexC].c;
-        val aC = data.positions!![m_indexC].a
-        val vC = data.velocities!![m_indexC].v
-        var wC = data.velocities!![m_indexC].w
+        val aC = data.positions!![indexC].a
+        val vC = data.velocities!![indexC].v
+        var wC = data.velocities!![indexC].w
 
         // Vec2 cD = data.positions[m_indexD].c;
-        val aD = data.positions!![m_indexD].a
-        val vD = data.velocities!![m_indexD].v
-        var wD = data.velocities!![m_indexD].w
+        val aD = data.positions!![indexD].a
+        val vD = data.velocities!![indexD].v
+        var wD = data.velocities!![indexD].w
 
         val qA = pool.popRot()
         val qB = pool.popRot()
@@ -274,136 +252,128 @@ class GearJoint(argWorldPool: IWorldPool, def: GearJointDef) : Joint(argWorldPoo
         qC.setRadians(aC)
         qD.setRadians(aD)
 
-        m_mass = 0.0f
+        mass = 0.0f
 
         val temp = pool.popVec2()
 
-        if (m_typeA === JointType.REVOLUTE) {
-            m_JvAC.setZero()
-            m_JwA = 1.0f
-            m_JwC = 1.0f
-            m_mass += m_iA + m_iC
+        if (typeA === JointType.REVOLUTE) {
+            JvAC.setZero()
+            JwA = 1.0f
+            JwC = 1.0f
+            mass += iA + iC
         } else {
             val rC = pool.popVec2()
             val rA = pool.popVec2()
-            Rot.mulToOutUnsafe(qC, m_localAxisC, m_JvAC)
-            Rot.mulToOutUnsafe(qC, temp.set(m_localAnchorC).subLocal(m_lcC), rC)
-            Rot.mulToOutUnsafe(qA, temp.set(m_localAnchorA).subLocal(m_lcA), rA)
-            m_JwC = Vec2.cross(rC, m_JvAC)
-            m_JwA = Vec2.cross(rA, m_JvAC)
-            m_mass += m_mC + m_mA + m_iC * m_JwC * m_JwC + m_iA * m_JwA * m_JwA
+            Rot.mulToOutUnsafe(qC, localAxisC, JvAC)
+            Rot.mulToOutUnsafe(qC, temp.set(localAnchorC).subLocal(lcC), rC)
+            Rot.mulToOutUnsafe(qA, temp.set(localAnchorA).subLocal(lcA), rA)
+            JwC = Vec2.cross(rC, JvAC)
+            JwA = Vec2.cross(rA, JvAC)
+            mass += mC + mA + iC * JwC * JwC + iA * JwA * JwA
             pool.pushVec2(2)
         }
 
-        if (m_typeB === JointType.REVOLUTE) {
-            m_JvBD.setZero()
-            m_JwB = ratio
-            m_JwD = ratio
-            m_mass += ratio * ratio * (m_iB + m_iD)
+        if (typeB === JointType.REVOLUTE) {
+            JvBD.setZero()
+            JwB = ratio
+            JwD = ratio
+            mass += ratio * ratio * (iB + iD)
         } else {
             val u = pool.popVec2()
             val rD = pool.popVec2()
             val rB = pool.popVec2()
-            Rot.mulToOutUnsafe(qD, m_localAxisD, u)
-            Rot.mulToOutUnsafe(qD, temp.set(m_localAnchorD).subLocal(m_lcD), rD)
-            Rot.mulToOutUnsafe(qB, temp.set(m_localAnchorB).subLocal(m_lcB), rB)
-            m_JvBD.set(u).mulLocal(ratio)
-            m_JwD = ratio * Vec2.cross(rD, u)
-            m_JwB = ratio * Vec2.cross(rB, u)
-            m_mass += ratio * ratio * (m_mD + m_mB) + m_iD * m_JwD * m_JwD + m_iB * m_JwB * m_JwB
+            Rot.mulToOutUnsafe(qD, localAxisD, u)
+            Rot.mulToOutUnsafe(qD, temp.set(localAnchorD).subLocal(lcD), rD)
+            Rot.mulToOutUnsafe(qB, temp.set(localAnchorB).subLocal(lcB), rB)
+            JvBD.set(u).mulLocal(ratio)
+            JwD = ratio * Vec2.cross(rD, u)
+            JwB = ratio * Vec2.cross(rB, u)
+            mass += ratio * ratio * (mD + mB) + iD * JwD * JwD + iB * JwB * JwB
             pool.pushVec2(3)
         }
 
         // Compute effective mass.
-        m_mass = if (m_mass > 0.0f) 1.0f / m_mass else 0.0f
+        mass = if (mass > 0.0f) 1.0f / mass else 0.0f
 
         if (data.step!!.warmStarting) {
-            vA.x += m_mA * m_impulse * m_JvAC.x
-            vA.y += m_mA * m_impulse * m_JvAC.y
-            wA += m_iA * m_impulse * m_JwA
+            vA.x += mA * impulse * JvAC.x
+            vA.y += mA * impulse * JvAC.y
+            wA += iA * impulse * JwA
 
-            vB.x += m_mB * m_impulse * m_JvBD.x
-            vB.y += m_mB * m_impulse * m_JvBD.y
-            wB += m_iB * m_impulse * m_JwB
+            vB.x += mB * impulse * JvBD.x
+            vB.y += mB * impulse * JvBD.y
+            wB += iB * impulse * JwB
 
-            vC.x -= m_mC * m_impulse * m_JvAC.x
-            vC.y -= m_mC * m_impulse * m_JvAC.y
-            wC -= m_iC * m_impulse * m_JwC
+            vC.x -= mC * impulse * JvAC.x
+            vC.y -= mC * impulse * JvAC.y
+            wC -= iC * impulse * JwC
 
-            vD.x -= m_mD * m_impulse * m_JvBD.x
-            vD.y -= m_mD * m_impulse * m_JvBD.y
-            wD -= m_iD * m_impulse * m_JwD
+            vD.x -= mD * impulse * JvBD.x
+            vD.y -= mD * impulse * JvBD.y
+            wD -= iD * impulse * JwD
         } else {
-            m_impulse = 0.0f
+            impulse = 0.0f
         }
         pool.pushVec2(1)
         pool.pushRot(4)
 
-        // data.velocities[m_indexA].v = vA;
-        data.velocities!![m_indexA].w = wA
-        // data.velocities[m_indexB].v = vB;
-        data.velocities!![m_indexB].w = wB
-        // data.velocities[m_indexC].v = vC;
-        data.velocities!![m_indexC].w = wC
-        // data.velocities[m_indexD].v = vD;
-        data.velocities!![m_indexD].w = wD
+        data.velocities!![indexA].w = wA
+        data.velocities!![indexB].w = wB
+        data.velocities!![indexC].w = wC
+        data.velocities!![indexD].w = wD
     }
 
     override fun solveVelocityConstraints(data: SolverData) {
-        val vA = data.velocities!![m_indexA].v
-        var wA = data.velocities!![m_indexA].w
-        val vB = data.velocities!![m_indexB].v
-        var wB = data.velocities!![m_indexB].w
-        val vC = data.velocities!![m_indexC].v
-        var wC = data.velocities!![m_indexC].w
-        val vD = data.velocities!![m_indexD].v
-        var wD = data.velocities!![m_indexD].w
+        val vA = data.velocities!![indexA].v
+        var wA = data.velocities!![indexA].w
+        val vB = data.velocities!![indexB].v
+        var wB = data.velocities!![indexB].w
+        val vC = data.velocities!![indexC].v
+        var wC = data.velocities!![indexC].w
+        val vD = data.velocities!![indexD].v
+        var wD = data.velocities!![indexD].w
 
         val temp1 = pool.popVec2()
         val temp2 = pool.popVec2()
-        var Cdot = Vec2.dot(m_JvAC, temp1.set(vA).subLocal(vC)) + Vec2.dot(m_JvBD, temp2.set(vB).subLocal(vD))
-        Cdot += m_JwA * wA - m_JwC * wC + (m_JwB * wB - m_JwD * wD)
+        var Cdot = Vec2.dot(JvAC, temp1.set(vA).subLocal(vC)) + Vec2.dot(JvBD, temp2.set(vB).subLocal(vD))
+        Cdot += JwA * wA - JwC * wC + (JwB * wB - JwD * wD)
         pool.pushVec2(2)
 
-        val impulse = -m_mass * Cdot
-        m_impulse += impulse
+        val impulse = -mass * Cdot
+        this.impulse += impulse
 
-        vA.x += m_mA * impulse * m_JvAC.x
-        vA.y += m_mA * impulse * m_JvAC.y
-        wA += m_iA * impulse * m_JwA
+        vA.x += mA * impulse * JvAC.x
+        vA.y += mA * impulse * JvAC.y
+        wA += iA * impulse * JwA
 
-        vB.x += m_mB * impulse * m_JvBD.x
-        vB.y += m_mB * impulse * m_JvBD.y
-        wB += m_iB * impulse * m_JwB
+        vB.x += mB * impulse * JvBD.x
+        vB.y += mB * impulse * JvBD.y
+        wB += iB * impulse * JwB
 
-        vC.x -= m_mC * impulse * m_JvAC.x
-        vC.y -= m_mC * impulse * m_JvAC.y
-        wC -= m_iC * impulse * m_JwC
+        vC.x -= mC * impulse * JvAC.x
+        vC.y -= mC * impulse * JvAC.y
+        wC -= iC * impulse * JwC
 
-        vD.x -= m_mD * impulse * m_JvBD.x
-        vD.y -= m_mD * impulse * m_JvBD.y
-        wD -= m_iD * impulse * m_JwD
+        vD.x -= mD * impulse * JvBD.x
+        vD.y -= mD * impulse * JvBD.y
+        wD -= iD * impulse * JwD
 
 
-        // data.velocities[m_indexA].v = vA;
-        data.velocities!![m_indexA].w = wA
-        // data.velocities[m_indexB].v = vB;
-        data.velocities!![m_indexB].w = wB
-        // data.velocities[m_indexC].v = vC;
-        data.velocities!![m_indexC].w = wC
-        // data.velocities[m_indexD].v = vD;
-        data.velocities!![m_indexD].w = wD
+        data.velocities!![indexA].w = wA
+        data.velocities!![indexB].w = wB
+        data.velocities!![indexC].w = wC
+        data.velocities!![indexD].w = wD
     }
 
     override fun solvePositionConstraints(data: SolverData): Boolean {
-        val cA = data.positions!![m_indexA].c
-        var aA = data.positions!![m_indexA].a
-        val cB = data.positions!![m_indexB].c
-        var aB = data.positions!![m_indexB].a
-        val cC = data.positions!![m_indexC].c
-        var aC = data.positions!![m_indexC].a
-        val cD = data.positions!![m_indexD].c
-        var aD = data.positions!![m_indexD].a
+        val cA = data.positions!![indexA].c
+        var aA = data.positions!![indexA].a
+        val cB = data.positions!![indexB].c
+        var aB = data.positions!![indexB].a
+        val cC = data.positions!![indexC].c
+        var aC = data.positions!![indexC].a
+        val cD = data.positions!![indexD].c
+        var aD = data.positions!![indexD].a
 
         val qA = pool.popRot()
         val qB = pool.popRot()
@@ -428,59 +398,59 @@ class GearJoint(argWorldPool: IWorldPool, def: GearJointDef) : Joint(argWorldPoo
         val JwD: Float
         var mass = 0.0f
 
-        if (m_typeA === JointType.REVOLUTE) {
+        if (typeA === JointType.REVOLUTE) {
             JvAC.setZero()
             JwA = 1.0f
             JwC = 1.0f
-            mass += m_iA + m_iC
+            mass += iA + iC
 
-            coordinateA = aA - aC - m_referenceAngleA
+            coordinateA = aA - aC - referenceAngleA
         } else {
             val rC = pool.popVec2()
             val rA = pool.popVec2()
             val pC = pool.popVec2()
             val pA = pool.popVec2()
-            Rot.mulToOutUnsafe(qC, m_localAxisC, JvAC)
-            Rot.mulToOutUnsafe(qC, temp.set(m_localAnchorC).subLocal(m_lcC), rC)
-            Rot.mulToOutUnsafe(qA, temp.set(m_localAnchorA).subLocal(m_lcA), rA)
+            Rot.mulToOutUnsafe(qC, localAxisC, JvAC)
+            Rot.mulToOutUnsafe(qC, temp.set(localAnchorC).subLocal(lcC), rC)
+            Rot.mulToOutUnsafe(qA, temp.set(localAnchorA).subLocal(lcA), rA)
             JwC = Vec2.cross(rC, JvAC)
             JwA = Vec2.cross(rA, JvAC)
-            mass += m_mC + m_mA + m_iC * JwC * JwC + m_iA * JwA * JwA
+            mass += mC + mA + iC * JwC * JwC + iA * JwA * JwA
 
-            pC.set(m_localAnchorC).subLocal(m_lcC)
+            pC.set(localAnchorC).subLocal(lcC)
             Rot.mulTransUnsafe(qC, temp.set(rA).addLocal(cA).subLocal(cC), pA)
-            coordinateA = Vec2.dot(pA.subLocal(pC), m_localAxisC)
+            coordinateA = Vec2.dot(pA.subLocal(pC), localAxisC)
             pool.pushVec2(4)
         }
 
-        if (m_typeB === JointType.REVOLUTE) {
+        if (typeB === JointType.REVOLUTE) {
             JvBD.setZero()
             JwB = ratio
             JwD = ratio
-            mass += ratio * ratio * (m_iB + m_iD)
+            mass += ratio * ratio * (iB + iD)
 
-            coordinateB = aB - aD - m_referenceAngleB
+            coordinateB = aB - aD - referenceAngleB
         } else {
             val u = pool.popVec2()
             val rD = pool.popVec2()
             val rB = pool.popVec2()
             val pD = pool.popVec2()
             val pB = pool.popVec2()
-            Rot.mulToOutUnsafe(qD, m_localAxisD, u)
-            Rot.mulToOutUnsafe(qD, temp.set(m_localAnchorD).subLocal(m_lcD), rD)
-            Rot.mulToOutUnsafe(qB, temp.set(m_localAnchorB).subLocal(m_lcB), rB)
+            Rot.mulToOutUnsafe(qD, localAxisD, u)
+            Rot.mulToOutUnsafe(qD, temp.set(localAnchorD).subLocal(lcD), rD)
+            Rot.mulToOutUnsafe(qB, temp.set(localAnchorB).subLocal(lcB), rB)
             JvBD.set(u).mulLocal(ratio)
             JwD = Vec2.cross(rD, u)
             JwB = Vec2.cross(rB, u)
-            mass += ratio * ratio * (m_mD + m_mB) + m_iD * JwD * JwD + m_iB * JwB * JwB
+            mass += ratio * ratio * (mD + mB) + iD * JwD * JwD + iB * JwB * JwB
 
-            pD.set(m_localAnchorD).subLocal(m_lcD)
+            pD.set(localAnchorD).subLocal(lcD)
             Rot.mulTransUnsafe(qD, temp.set(rB).addLocal(cB).subLocal(cD), pB)
-            coordinateB = Vec2.dot(pB.subLocal(pD), m_localAxisD)
+            coordinateB = Vec2.dot(pB.subLocal(pD), localAxisD)
             pool.pushVec2(5)
         }
 
-        val C = coordinateA + ratio * coordinateB - m_constant
+        val C = coordinateA + ratio * coordinateB - constant
 
         var impulse = 0.0f
         if (mass > 0.0f) {
@@ -489,30 +459,26 @@ class GearJoint(argWorldPool: IWorldPool, def: GearJointDef) : Joint(argWorldPoo
         pool.pushVec2(3)
         pool.pushRot(4)
 
-        cA.x += m_mA * impulse * JvAC.x
-        cA.y += m_mA * impulse * JvAC.y
-        aA += m_iA * impulse * JwA
+        cA.x += mA * impulse * JvAC.x
+        cA.y += mA * impulse * JvAC.y
+        aA += iA * impulse * JwA
 
-        cB.x += m_mB * impulse * JvBD.x
-        cB.y += m_mB * impulse * JvBD.y
-        aB += m_iB * impulse * JwB
+        cB.x += mB * impulse * JvBD.x
+        cB.y += mB * impulse * JvBD.y
+        aB += iB * impulse * JwB
 
-        cC.x -= m_mC * impulse * JvAC.x
-        cC.y -= m_mC * impulse * JvAC.y
-        aC -= m_iC * impulse * JwC
+        cC.x -= mC * impulse * JvAC.x
+        cC.y -= mC * impulse * JvAC.y
+        aC -= iC * impulse * JwC
 
-        cD.x -= m_mD * impulse * JvBD.x
-        cD.y -= m_mD * impulse * JvBD.y
-        aD -= m_iD * impulse * JwD
+        cD.x -= mD * impulse * JvBD.x
+        cD.y -= mD * impulse * JvBD.y
+        aD -= iD * impulse * JwD
 
-        // data.positions[m_indexA].c = cA;
-        data.positions!![m_indexA].a = aA
-        // data.positions[m_indexB].c = cB;
-        data.positions!![m_indexB].a = aB
-        // data.positions[m_indexC].c = cC;
-        data.positions!![m_indexC].a = aC
-        // data.positions[m_indexD].c = cD;
-        data.positions!![m_indexD].a = aD
+        data.positions!![indexA].a = aA
+        data.positions!![indexB].a = aB
+        data.positions!![indexC].a = aC
+        data.positions!![indexD].a = aD
 
         // TODO_ERIN not implemented
         return linearError < Settings.linearSlop

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/GearJointDef.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/GearJointDef.kt
@@ -33,16 +33,15 @@ package org.jbox2d.dynamics.joints
  * @author Daniel Murphy
  */
 class GearJointDef : JointDef(JointType.GEAR) {
+
     /**
      * The first revolute/prismatic joint attached to the gear joint.
      */
-
     var joint1: Joint? = null
 
     /**
      * The second revolute/prismatic joint attached to the gear joint.
      */
-
     var joint2: Joint? = null
 
     /**
@@ -50,6 +49,5 @@ class GearJointDef : JointDef(JointType.GEAR) {
      *
      * @see GearJoint
      */
-
     var ratio: Float = 0f
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/Jacobian.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/Jacobian.kt
@@ -30,6 +30,5 @@ class Jacobian {
     val linearA = Vec2()
 
     var angularA: Float = 0f
-
     var angularB: Float = 0f
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/JointDef.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/JointDef.kt
@@ -31,33 +31,25 @@ import org.jbox2d.userdata.*
  * @author Daniel Murphy
  */
 open class JointDef(
-        /**
-         * The joint type is set automatically for concrete joint types.
-         */
 
-        var type: JointType) : Box2dTypedUserData by Box2dTypedUserData.Mixin() {
+    /**
+     * The joint type is set automatically for concrete joint types.
+     */
+    var type: JointType) : Box2dTypedUserData by Box2dTypedUserData.Mixin() {
 
     /**
      * Use this to attach application specific data to your joints.
      */
-
     var userData: Any? = null
 
-    /**
-     * The first attached body.
-     */
-
+    /** The first attached body. */
     var bodyA: Body? = null
 
-    /**
-     * The second attached body.
-     */
-
+    /** The second attached body. */
     var bodyB: Body? = null
 
     /**
      * Set this flag to true if the attached bodies should collide.
      */
-
     var collideConnected: Boolean = false
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/JointEdge.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/JointEdge.kt
@@ -38,24 +38,13 @@ class JointEdge {
     /**
      * Provides quick access to the other body attached
      */
-
     var other: Body? = null
 
-    /**
-     * the joint
-     */
-
+    /** the joint */
     var joint: Joint? = null
 
-    /**
-     * the previous joint edge in the body's joint list
-     */
-
+    /** the previous joint edge in the body's joint list */
     var prev: JointEdge? = null
-
-    /**
-     * the next joint edge in the body's joint list
-     */
-
+    /** the next joint edge in the body's joint list */
     var next: JointEdge? = null
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/MotorJoint.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/MotorJoint.kt
@@ -8,18 +8,6 @@ import org.jbox2d.dynamics.SolverData
 import org.jbox2d.internal.*
 import org.jbox2d.pooling.IWorldPool
 
-//Point-to-point constraint
-//Cdot = v2 - v1
-//   = v2 + cross(w2, r2) - v1 - cross(w1, r1)
-//J = [-I -r1_skew I r2_skew ]
-//Identity used:
-//w k % (rx i + ry j) = w * (-ry i + rx j)
-
-//Angle constraint
-//Cdot = w2 - w1
-//J = [0 0 -1 0 0 1]
-//K = invI1 + invI2
-
 /**
  * A motor joint is used to control the relative motion between two bodies. A typical usage is to
  * control the movement of a dynamic body with respect to the ground.
@@ -29,85 +17,70 @@ import org.jbox2d.pooling.IWorldPool
 class MotorJoint(pool: IWorldPool, def: MotorJointDef) : Joint(pool, def) {
 
     // Solver shared
-    /**
-     * Get the target linear offset, in frame A, in meters. Do not modify.
-     */
-    /**
-     * Set the target linear offset, in frame A, in meters.
-     */
+    /** The target linear offset, in frame A, in meters. Do not modify. */
     var linearOffset = Vec2()
         set(linearOffset) {
             if (linearOffset.x != this.linearOffset.x || linearOffset.y != this.linearOffset.y) {
-                m_bodyA!!.isAwake = true
-                m_bodyB!!.isAwake = true
+                bodyA!!.isAwake = true
+                bodyB!!.isAwake = true
                 this.linearOffset.set(linearOffset)
             }
         }
-    private var m_angularOffset: Float = def.angularOffset
-    private val m_linearImpulse = Vec2()
-    private var m_angularImpulse: Float = 0f
-    private var m_maxForce: Float = def.maxForce
-    private var m_maxTorque: Float = def.maxTorque
+    private var _angularOffset: Float = def.angularOffset
+    private val linearImpulse = Vec2()
+    private var angularImpulse: Float = 0f
+    private var _maxForce: Float = def.maxForce
+    private var _maxTorque: Float = def.maxTorque
 
     var correctionFactor: Float = def.correctionFactor
 
     // Solver temp
-    private var m_indexA: Int = 0
-    private var m_indexB: Int = 0
-    private val m_rA = Vec2()
-    private val m_rB = Vec2()
-    private val m_localCenterA = Vec2()
-    private val m_localCenterB = Vec2()
-    private val m_linearError = Vec2()
-    private var m_angularError: Float = 0.toFloat()
-    private var m_invMassA: Float = 0.toFloat()
-    private var m_invMassB: Float = 0.toFloat()
-    private var m_invIA: Float = 0.toFloat()
-    private var m_invIB: Float = 0.toFloat()
-    private val m_linearMass = Mat22()
-    private var m_angularMass: Float = 0.toFloat()
+    private var indexA: Int = 0
+    private var indexB: Int = 0
+    private val rA = Vec2()
+    private val rB = Vec2()
+    private val localCenterA = Vec2()
+    private val localCenterB = Vec2()
+    private val linearError = Vec2()
+    private var angularError: Float = 0f
+    private var invMassA: Float = 0f
+    private var invMassB: Float = 0f
+    private var invIA: Float = 0f
+    private var invIB: Float = 0f
+    private val linearMass = Mat22()
+    private var angularMass: Float = 0f
 
     /**
-     * Set the target angular offset, in radians.
-     *
-     * @param angularOffset
+     * Target angular offset in radians.
      */
     var angularOffset: Float
-        get() = m_angularOffset
+        get() = _angularOffset
         set(angularOffset) {
-            if (angularOffset != m_angularOffset) {
-                m_bodyA!!.isAwake = true
-                m_bodyB!!.isAwake = true
-                m_angularOffset = angularOffset
+            if (angularOffset != _angularOffset) {
+                bodyA!!.isAwake = true
+                bodyB!!.isAwake = true
+                _angularOffset = angularOffset
             }
         }
 
     /**
-     * Get the maximum friction force in N.
-     */
-    /**
-     * Set the maximum friction force in N.
-     *
-     * @param force
+     * Maximum friction force in N.
      */
     var maxForce: Float
-        get() = m_maxForce
+        get() = _maxForce
         set(force) {
             assert(force >= 0.0f)
-            m_maxForce = force
+            _maxForce = force
         }
 
     /**
-     * Get the maximum friction torque in N*m.
-     */
-    /**
-     * Set the maximum friction torque in N*m.
+     * Maximum friction torque in N*m.
      */
     var maxTorque: Float
-        get() = m_maxTorque
+        get() = _maxTorque
         set(torque) {
             assert(torque >= 0.0f)
-            m_maxTorque = torque
+            _maxTorque = torque
         }
 
     init {
@@ -115,19 +88,19 @@ class MotorJoint(pool: IWorldPool, def: MotorJointDef) : Joint(pool, def) {
     }
 
     override fun getAnchorA(out: Vec2) {
-        out.set(m_bodyA!!.position)
+        out.set(bodyA!!.position)
     }
 
     override fun getAnchorB(out: Vec2) {
-        out.set(m_bodyB!!.position)
+        out.set(bodyB!!.position)
     }
 
-    override fun getReactionForce(inv_dt: Float, out: Vec2) {
-        out.set(m_linearImpulse).mulLocal(inv_dt)
+    override fun getReactionForce(invDt: Float, out: Vec2) {
+        out.set(linearImpulse).mulLocal(invDt)
     }
 
-    override fun getReactionTorque(inv_dt: Float): Float {
-        return m_angularImpulse * inv_dt
+    override fun getReactionTorque(invDt: Float): Float {
+        return angularImpulse * invDt
     }
 
     /**
@@ -138,24 +111,24 @@ class MotorJoint(pool: IWorldPool, def: MotorJointDef) : Joint(pool, def) {
     }
 
     override fun initVelocityConstraints(data: SolverData) {
-        m_indexA = m_bodyA!!.m_islandIndex
-        m_indexB = m_bodyB!!.m_islandIndex
-        m_localCenterA.set(m_bodyA!!.m_sweep.localCenter)
-        m_localCenterB.set(m_bodyB!!.m_sweep.localCenter)
-        m_invMassA = m_bodyA!!.m_invMass
-        m_invMassB = m_bodyB!!.m_invMass
-        m_invIA = m_bodyA!!.m_invI
-        m_invIB = m_bodyB!!.m_invI
+        indexA = bodyA!!.islandIndex
+        indexB = bodyB!!.islandIndex
+        localCenterA.set(bodyA!!.sweep.localCenter)
+        localCenterB.set(bodyB!!.sweep.localCenter)
+        invMassA = bodyA!!.invMass
+        invMassB = bodyB!!.invMass
+        invIA = bodyA!!.invI
+        invIB = bodyB!!.invI
 
-        val cA = data.positions!![m_indexA].c
-        val aA = data.positions!![m_indexA].a
-        val vA = data.velocities!![m_indexA].v
-        var wA = data.velocities!![m_indexA].w
+        val cA = data.positions!![indexA].c
+        val aA = data.positions!![indexA].a
+        val vA = data.velocities!![indexA].v
+        var wA = data.velocities!![indexA].w
 
-        val cB = data.positions!![m_indexB].c
-        val aB = data.positions!![m_indexB].a
-        val vB = data.velocities!![m_indexB].v
-        var wB = data.velocities!![m_indexB].w
+        val cB = data.positions!![indexB].c
+        val aB = data.positions!![indexB].a
+        val vB = data.velocities!![indexB].v
+        var wB = data.velocities!![indexB].w
 
         val qA = pool.popRot()
         val qB = pool.popRot()
@@ -168,10 +141,10 @@ class MotorJoint(pool: IWorldPool, def: MotorJointDef) : Joint(pool, def) {
         // Compute the effective mass matrix.
         // m_rA = b2Mul(qA, -m_localCenterA);
         // m_rB = b2Mul(qB, -m_localCenterB);
-        m_rA.x = qA.c * -m_localCenterA.x - qA.s * -m_localCenterA.y
-        m_rA.y = qA.s * -m_localCenterA.x + qA.c * -m_localCenterA.y
-        m_rB.x = qB.c * -m_localCenterB.x - qB.s * -m_localCenterB.y
-        m_rB.y = qB.s * -m_localCenterB.x + qB.c * -m_localCenterB.y
+        rA.x = qA.c * -localCenterA.x - qA.s * -localCenterA.y
+        rA.y = qA.s * -localCenterA.x + qA.c * -localCenterA.y
+        rB.x = qB.c * -localCenterB.x - qB.s * -localCenterB.y
+        rB.y = qB.s * -localCenterB.x + qB.c * -localCenterB.y
 
         // J = [-I -r1_skew I r2_skew]
         // [ 0 -1 0 1]
@@ -181,45 +154,45 @@ class MotorJoint(pool: IWorldPool, def: MotorJointDef) : Joint(pool, def) {
         // K = [ mA+r1y^2*iA+mB+r2y^2*iB, -r1y*iA*r1x-r2y*iB*r2x, -r1y*iA-r2y*iB]
         // [ -r1y*iA*r1x-r2y*iB*r2x, mA+r1x^2*iA+mB+r2x^2*iB, r1x*iA+r2x*iB]
         // [ -r1y*iA-r2y*iB, r1x*iA+r2x*iB, iA+iB]
-        val mA = m_invMassA
-        val mB = m_invMassB
-        val iA = m_invIA
-        val iB = m_invIB
+        val mA = invMassA
+        val mB = invMassB
+        val iA = invIA
+        val iB = invIB
 
-        K.ex.x = mA + mB + iA * m_rA.y * m_rA.y + iB * m_rB.y * m_rB.y
-        K.ex.y = -iA * m_rA.x * m_rA.y - iB * m_rB.x * m_rB.y
+        K.ex.x = mA + mB + iA * rA.y * rA.y + iB * rB.y * rB.y
+        K.ex.y = -iA * rA.x * rA.y - iB * rB.x * rB.y
         K.ey.x = K.ex.y
-        K.ey.y = mA + mB + iA * m_rA.x * m_rA.x + iB * m_rB.x * m_rB.x
+        K.ey.y = mA + mB + iA * rA.x * rA.x + iB * rB.x * rB.x
 
-        K.invertToOut(m_linearMass)
+        K.invertToOut(linearMass)
 
-        m_angularMass = iA + iB
-        if (m_angularMass > 0.0f) {
-            m_angularMass = 1.0f / m_angularMass
+        angularMass = iA + iB
+        if (angularMass > 0.0f) {
+            angularMass = 1.0f / angularMass
         }
 
-        // m_linearError = cB + m_rB - cA - m_rA - b2Mul(qA, m_linearOffset);
+        // linearError = cB + m_rB - cA - m_rA - b2Mul(qA, m_linearOffset);
         Rot.mulToOutUnsafe(qA, linearOffset, temp)
-        m_linearError.x = cB.x + m_rB.x - cA.x - m_rA.x - temp.x
-        m_linearError.y = cB.y + m_rB.y - cA.y - m_rA.y - temp.y
-        m_angularError = aB - aA - m_angularOffset
+        linearError.x = cB.x + rB.x - cA.x - rA.x - temp.x
+        linearError.y = cB.y + rB.y - cA.y - rA.y - temp.y
+        angularError = aB - aA - _angularOffset
 
         if (data.step!!.warmStarting) {
             // Scale impulses to support a variable time step.
-            m_linearImpulse.x *= data.step!!.dtRatio
-            m_linearImpulse.y *= data.step!!.dtRatio
-            m_angularImpulse *= data.step!!.dtRatio
+            linearImpulse.x *= data.step!!.dtRatio
+            linearImpulse.y *= data.step!!.dtRatio
+            angularImpulse *= data.step!!.dtRatio
 
-            val P = m_linearImpulse
+            val P = linearImpulse
             vA.x -= mA * P.x
             vA.y -= mA * P.y
-            wA -= iA * (m_rA.x * P.y - m_rA.y * P.x + m_angularImpulse)
+            wA -= iA * (rA.x * P.y - rA.y * P.x + angularImpulse)
             vB.x += mB * P.x
             vB.y += mB * P.y
-            wB += iB * (m_rB.x * P.y - m_rB.y * P.x + m_angularImpulse)
+            wB += iB * (rB.x * P.y - rB.y * P.x + angularImpulse)
         } else {
-            m_linearImpulse.setZero()
-            m_angularImpulse = 0.0f
+            linearImpulse.setZero()
+            angularImpulse = 0.0f
         }
 
         pool.pushVec2(1)
@@ -227,36 +200,36 @@ class MotorJoint(pool: IWorldPool, def: MotorJointDef) : Joint(pool, def) {
         pool.pushRot(2)
 
         // data.velocities[m_indexA].v = vA;
-        data.velocities!![m_indexA].w = wA
+        data.velocities!![indexA].w = wA
         // data.velocities[m_indexB].v = vB;
-        data.velocities!![m_indexB].w = wB
+        data.velocities!![indexB].w = wB
     }
 
     override fun solveVelocityConstraints(data: SolverData) {
-        val vA = data.velocities!![m_indexA].v
-        var wA = data.velocities!![m_indexA].w
-        val vB = data.velocities!![m_indexB].v
-        var wB = data.velocities!![m_indexB].w
+        val vA = data.velocities!![indexA].v
+        var wA = data.velocities!![indexA].w
+        val vB = data.velocities!![indexB].v
+        var wB = data.velocities!![indexB].w
 
-        val mA = m_invMassA
-        val mB = m_invMassB
-        val iA = m_invIA
-        val iB = m_invIB
+        val mA = invMassA
+        val mB = invMassB
+        val iA = invIA
+        val iB = invIB
 
         val h = data.step!!.dt
-        val inv_h = data.step!!.inv_dt
+        val inv_h = data.step!!.invDt
 
         val temp = pool.popVec2()
 
         // Solve angular friction
         run {
-            val Cdot = wB - wA + inv_h * correctionFactor * m_angularError
-            var impulse = -m_angularMass * Cdot
+            val Cdot = wB - wA + inv_h * correctionFactor * angularError
+            var impulse = -angularMass * Cdot
 
-            val oldImpulse = m_angularImpulse
-            val maxImpulse = h * m_maxTorque
-            m_angularImpulse = MathUtils.clamp(m_angularImpulse + impulse, -maxImpulse, maxImpulse)
-            impulse = m_angularImpulse - oldImpulse
+            val oldImpulse = angularImpulse
+            val maxImpulse = h * _maxTorque
+            angularImpulse = MathUtils.clamp(angularImpulse + impulse, -maxImpulse, maxImpulse)
+            impulse = angularImpulse - oldImpulse
 
             wA -= iA * impulse
             wB += iB * impulse
@@ -267,45 +240,43 @@ class MotorJoint(pool: IWorldPool, def: MotorJointDef) : Joint(pool, def) {
         // Solve linear friction
         run {
             // Cdot = vB + b2Cross(wB, m_rB) - vA - b2Cross(wA, m_rA) + inv_h * m_correctionFactor *
-            // m_linearError;
-            Cdot.x = vB.x + -wB * m_rB.y - vA.x - -wA * m_rA.y + inv_h * correctionFactor * m_linearError.x
-            Cdot.y = vB.y + wB * m_rB.x - vA.y - wA * m_rA.x + inv_h * correctionFactor * m_linearError.y
+            // linearError;
+            Cdot.x = vB.x + -wB * rB.y - vA.x - -wA * rA.y + inv_h * correctionFactor * linearError.x
+            Cdot.y = vB.y + wB * rB.x - vA.y - wA * rA.x + inv_h * correctionFactor * linearError.y
 
             val impulse = temp
-            Mat22.mulToOutUnsafe(m_linearMass, Cdot, impulse)
+            Mat22.mulToOutUnsafe(linearMass, Cdot, impulse)
             impulse.negateLocal()
             val oldImpulse = pool.popVec2()
-            oldImpulse.set(m_linearImpulse)
-            m_linearImpulse.addLocal(impulse)
+            oldImpulse.set(linearImpulse)
+            linearImpulse.addLocal(impulse)
 
-            val maxImpulse = h * m_maxForce
+            val maxImpulse = h * _maxForce
 
-            if (m_linearImpulse.lengthSquared() > maxImpulse * maxImpulse) {
-                m_linearImpulse.normalize()
-                m_linearImpulse.mulLocal(maxImpulse)
+            if (linearImpulse.lengthSquared() > maxImpulse * maxImpulse) {
+                linearImpulse.normalize()
+                linearImpulse.mulLocal(maxImpulse)
             }
 
-            impulse.x = m_linearImpulse.x - oldImpulse.x
-            impulse.y = m_linearImpulse.y - oldImpulse.y
+            impulse.x = linearImpulse.x - oldImpulse.x
+            impulse.y = linearImpulse.y - oldImpulse.y
 
             vA.x -= mA * impulse.x
             vA.y -= mA * impulse.y
-            wA -= iA * (m_rA.x * impulse.y - m_rA.y * impulse.x)
+            wA -= iA * (rA.x * impulse.y - rA.y * impulse.x)
 
             vB.x += mB * impulse.x
             vB.y += mB * impulse.y
-            wB += iB * (m_rB.x * impulse.y - m_rB.y * impulse.x)
+            wB += iB * (rB.x * impulse.y - rB.y * impulse.x)
         }
 
         pool.pushVec2(3)
 
         // data.velocities[m_indexA].v.set(vA);
-        data.velocities!![m_indexA].w = wA
+        data.velocities!![indexA].w = wA
         // data.velocities[m_indexB].v.set(vB);
-        data.velocities!![m_indexB].w = wB
+        data.velocities!![indexB].w = wB
     }
 
-    override fun solvePositionConstraints(data: SolverData): Boolean {
-        return true
-    }
+    override fun solvePositionConstraints(data: SolverData) = true
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/MotorJointDef.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/MotorJointDef.kt
@@ -9,34 +9,22 @@ import org.jbox2d.dynamics.Body
  * @author dmurph
  */
 class MotorJointDef : JointDef(JointType.MOTOR) {
+
     /**
      * Position of bodyB minus the position of bodyA, in bodyA's frame, in meters.
      */
-
     val linearOffset = Vec2()
 
-    /**
-     * The bodyB angle minus bodyA angle in radians.
-     */
-
+    /** The bodyB angle minus bodyA angle in radians. */
     var angularOffset: Float = 0f
 
-    /**
-     * The maximum motor force in N.
-     */
-
+    /** The maximum motor force in N. */
     var maxForce: Float = 1f
 
-    /**
-     * The maximum motor torque in N-m.
-     */
-
+    /** The maximum motor torque in N-m. */
     var maxTorque: Float = 1f
 
-    /**
-     * Position correction factor in the range [0,1].
-     */
-
+    /** Position correction factor in the range [0,1]. */
     var correctionFactor: Float = .3f
 
     fun initialize(bA: Body, bB: Body) {

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/MouseJoint.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/MouseJoint.kt
@@ -41,68 +41,65 @@ import org.jbox2d.pooling.IWorldPool
  *
  * @author Daniel
  */
-class MouseJoint constructor(argWorld: IWorldPool, def: MouseJointDef) : Joint(argWorld, def) {
-    private val m_localAnchorB = Vec2()
-    var target = Vec2()
-        set(target) {
-            if (m_bodyB!!.isAwake == false) {
-                m_bodyB!!.isAwake = true
-            }
-            this.target.set(target)
-        }
-    // / set/get the frequency in Hertz.
-
-    var frequency: Float = 0.toFloat()
-    // / set/get the damping ratio (dimensionless).
-
-    var dampingRatio: Float = 0.toFloat()
-    private var m_beta: Float = 0.toFloat()
-
-    // Solver shared
-    private val m_impulse = Vec2()
-    // / set/get the maximum force in Newtons.
-
-    var maxForce: Float = 0.toFloat()
-    private var m_gamma: Float = 0.toFloat()
-
-    // Solver temp
-    private var m_indexB: Int = 0
-    private val m_rB = Vec2()
-    private val m_localCenterB = Vec2()
-    private var m_invMassB: Float = 0.toFloat()
-    private var m_invIB: Float = 0.toFloat()
-    private val m_mass = Mat22()
-    private val m_C = Vec2()
+class MouseJoint(argWorld: IWorldPool, def: MouseJointDef) : Joint(argWorld, def) {
 
     init {
         assert(def.target.isValid)
         assert(def.maxForce >= 0)
         assert(def.frequencyHz >= 0)
         assert(def.dampingRatio >= 0)
+    }
 
+    private val localAnchorB = Vec2()
+    var target = Vec2()
+        set(target) {
+            if (!bodyB!!.isAwake) {
+                bodyB!!.isAwake = true
+            }
+            this.target.set(target)
+        }
+
+    /** Frequency in Hertz. */
+    var frequency: Float = def.frequencyHz
+
+    /** Damping ratio (dimensionless) */
+    var dampingRatio: Float = def.dampingRatio
+
+    private var beta: Float = 0f
+
+    // Solver shared
+    private val impulse = Vec2()
+
+    /* Maximum force in Newtons. */
+    var maxForce: Float = def.maxForce
+
+    private var gamma: Float = 0f
+
+    // Solver temp
+    private var indexB: Int = 0
+    private val rB = Vec2()
+    private val localCenterB = Vec2()
+    private var invMassB: Float = 0f
+    private var invIB: Float = 0f
+    private val mass = Mat22()
+    private val C = Vec2()
+
+    init {
         target.set(def.target)
-        Transform.mulTransToOutUnsafe(m_bodyB!!.m_xf, target, m_localAnchorB)
-
-        maxForce = def.maxForce
-        m_impulse.setZero()
-
-        frequency = def.frequencyHz
-        dampingRatio = def.dampingRatio
-
-        m_beta = 0f
-        m_gamma = 0f
+        Transform.mulTransToOutUnsafe(bodyB!!.xf, target, localAnchorB)
+        impulse.setZero()
     }
 
-    override fun getAnchorA(argOut: Vec2) {
-        argOut.set(target)
+    override fun getAnchorA(out: Vec2) {
+        out.set(target)
     }
 
-    override fun getAnchorB(argOut: Vec2) {
-        m_bodyB!!.getWorldPointToOut(m_localAnchorB, argOut)
+    override fun getAnchorB(out: Vec2) {
+        bodyB!!.getWorldPointToOut(localAnchorB, out)
     }
 
-    override fun getReactionForce(invDt: Float, argOut: Vec2) {
-        argOut.set(m_impulse).mulLocal(invDt)
+    override fun getReactionForce(invDt: Float, out: Vec2) {
+        out.set(impulse).mulLocal(invDt)
     }
 
     override fun getReactionTorque(invDt: Float): Float {
@@ -110,21 +107,21 @@ class MouseJoint constructor(argWorld: IWorldPool, def: MouseJointDef) : Joint(a
     }
 
     override fun initVelocityConstraints(data: SolverData) {
-        m_indexB = m_bodyB!!.m_islandIndex
-        m_localCenterB.set(m_bodyB!!.m_sweep.localCenter)
-        m_invMassB = m_bodyB!!.m_invMass
-        m_invIB = m_bodyB!!.m_invI
+        indexB = bodyB!!.islandIndex
+        localCenterB.set(bodyB!!.sweep.localCenter)
+        invMassB = bodyB!!.invMass
+        invIB = bodyB!!.invI
 
-        val cB = data.positions!![m_indexB].c
-        val aB = data.positions!![m_indexB].a
-        val vB = data.velocities!![m_indexB].v
-        var wB = data.velocities!![m_indexB].w
+        val cB = data.positions!![indexB].c
+        val aB = data.positions!![indexB].a
+        val vB = data.velocities!![indexB].v
+        var wB = data.velocities!![indexB].w
 
         val qB = pool.popRot()
 
         qB.setRadians(aB)
 
-        val mass = m_bodyB!!.m_mass
+        val mass = bodyB!!.mass
 
         // Frequency
         val omega = 2.0f * MathUtils.PI * frequency
@@ -140,88 +137,82 @@ class MouseJoint constructor(argWorld: IWorldPool, def: MouseJointDef) : Joint(a
         // beta has units of inverse time.
         val h = data.step!!.dt
         assert(d + h * k > Settings.EPSILON)
-        m_gamma = h * (d + h * k)
-        if (m_gamma != 0.0f) {
-            m_gamma = 1.0f / m_gamma
+        gamma = h * (d + h * k)
+        if (gamma != 0.0f) {
+            gamma = 1.0f / gamma
         }
-        m_beta = h * k * m_gamma
+        beta = h * k * gamma
 
         val temp = pool.popVec2()
 
         // Compute the effective mass matrix.
-        Rot.mulToOutUnsafe(qB, temp.set(m_localAnchorB).subLocal(m_localCenterB), m_rB)
+        Rot.mulToOutUnsafe(qB, temp.set(localAnchorB).subLocal(localCenterB), rB)
 
         // K = [(1/m1 + 1/m2) * eye(2) - skew(r1) * invI1 * skew(r1) - skew(r2) * invI2 * skew(r2)]
         // = [1/m1+1/m2 0 ] + invI1 * [r1.y*r1.y -r1.x*r1.y] + invI2 * [r1.y*r1.y -r1.x*r1.y]
         // [ 0 1/m1+1/m2] [-r1.x*r1.y r1.x*r1.x] [-r1.x*r1.y r1.x*r1.x]
         val K = pool.popMat22()
-        K.ex.x = m_invMassB + m_invIB * m_rB.y * m_rB.y + m_gamma
-        K.ex.y = -m_invIB * m_rB.x * m_rB.y
+        K.ex.x = invMassB + invIB * rB.y * rB.y + gamma
+        K.ex.y = -invIB * rB.x * rB.y
         K.ey.x = K.ex.y
-        K.ey.y = m_invMassB + m_invIB * m_rB.x * m_rB.x + m_gamma
+        K.ey.y = invMassB + invIB * rB.x * rB.x + gamma
 
-        K.invertToOut(m_mass)
+        K.invertToOut(this.mass)
 
-        m_C.set(cB).addLocal(m_rB).subLocal(target)
-        m_C.mulLocal(m_beta)
+        C.set(cB).addLocal(rB).subLocal(target)
+        C.mulLocal(beta)
 
         // Cheat with some damping
         wB *= 0.98f
 
         if (data.step!!.warmStarting) {
-            m_impulse.mulLocal(data.step!!.dtRatio)
-            vB.x += m_invMassB * m_impulse.x
-            vB.y += m_invMassB * m_impulse.y
-            wB += m_invIB * Vec2.cross(m_rB, m_impulse)
+            impulse.mulLocal(data.step!!.dtRatio)
+            vB.x += invMassB * impulse.x
+            vB.y += invMassB * impulse.y
+            wB += invIB * Vec2.cross(rB, impulse)
         } else {
-            m_impulse.setZero()
+            impulse.setZero()
         }
 
-        //    data.velocities[m_indexB].v.set(vB);
-        data.velocities!![m_indexB].w = wB
+        data.velocities!![indexB].w = wB
 
         pool.pushVec2(1)
         pool.pushMat22(1)
         pool.pushRot(1)
     }
 
-    override fun solvePositionConstraints(data: SolverData): Boolean {
-        return true
-    }
+    override fun solvePositionConstraints(data: SolverData) = true
 
     override fun solveVelocityConstraints(data: SolverData) {
-
-        val vB = data.velocities!![m_indexB].v
-        var wB = data.velocities!![m_indexB].w
+        val vB = data.velocities!![indexB].v
+        var wB = data.velocities!![indexB].w
 
         // Cdot = v + cross(w, r)
         val Cdot = pool.popVec2()
-        Vec2.crossToOutUnsafe(wB, m_rB, Cdot)
+        Vec2.crossToOutUnsafe(wB, rB, Cdot)
         Cdot.addLocal(vB)
 
         val impulse = pool.popVec2()
         val temp = pool.popVec2()
 
-        temp.set(m_impulse).mulLocal(m_gamma).addLocal(m_C).addLocal(Cdot).negateLocal()
-        Mat22.mulToOutUnsafe(m_mass, temp, impulse)
+        temp.set(this.impulse).mulLocal(gamma).addLocal(C).addLocal(Cdot).negateLocal()
+        Mat22.mulToOutUnsafe(mass, temp, impulse)
 
         val oldImpulse = temp
-        oldImpulse.set(m_impulse)
-        m_impulse.addLocal(impulse)
+        oldImpulse.set(this.impulse)
+        this.impulse.addLocal(impulse)
         val maxImpulse = data.step!!.dt * maxForce
-        if (m_impulse.lengthSquared() > maxImpulse * maxImpulse) {
-            m_impulse.mulLocal(maxImpulse / m_impulse.length())
+        if (this.impulse.lengthSquared() > maxImpulse * maxImpulse) {
+            this.impulse.mulLocal(maxImpulse / this.impulse.length())
         }
-        impulse.set(m_impulse).subLocal(oldImpulse)
+        impulse.set(this.impulse).subLocal(oldImpulse)
 
-        vB.x += m_invMassB * impulse.x
-        vB.y += m_invMassB * impulse.y
-        wB += m_invIB * Vec2.cross(m_rB, impulse)
+        vB.x += invMassB * impulse.x
+        vB.y += invMassB * impulse.y
+        wB += invIB * Vec2.cross(rB, impulse)
 
-        //    data.velocities[m_indexB].v.set(vB);
-        data.velocities!![m_indexB].w = wB
+        data.velocities!![indexB].w = wB
 
         pool.pushVec2(3)
     }
-
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/MouseJointDef.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/MouseJointDef.kt
@@ -31,28 +31,25 @@ import org.jbox2d.common.Vec2
  * @author Daniel
  */
 class MouseJointDef : JointDef(JointType.MOUSE) {
+
     /**
      * The initial world target point. This is assumed to coincide with the body anchor initially.
      */
-
     val target = Vec2(0f, 0f)
 
     /**
      * The maximum constraint force that can be exerted to move the candidate body. Usually you will
      * express as some multiple of the weight (multiplier * mass * gravity).
      */
-
     var maxForce: Float = 0f
 
     /**
      * The response speed.
      */
-
     var frequencyHz: Float = .5f
 
     /**
      * The damping ratio. 0 = no damping, 1 = critical damping.
      */
-
     var dampingRatio: Float = .7f
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/PrismaticJointDef.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/PrismaticJointDef.kt
@@ -39,23 +39,19 @@ import org.jbox2d.dynamics.Body
  */
 class PrismaticJointDef : JointDef(JointType.PRISMATIC) {
 
-
     /**
      * The local anchor point relative to body1's origin.
      */
-
     val localAnchorA: Vec2 = Vec2()
 
     /**
      * The local anchor point relative to body2's origin.
      */
-
     val localAnchorB: Vec2 = Vec2()
 
     /**
      * The local translation axis in body1.
      */
-
     val localAxisA: Vec2 = Vec2(1.0f, 0.0f)
 
     /**
@@ -80,37 +76,31 @@ class PrismaticJointDef : JointDef(JointType.PRISMATIC) {
     /**
      * Enable/disable the joint limit.
      */
-
     var enableLimit: Boolean = false
 
     /**
      * The lower translation limit, usually in meters.
      */
-
     var lowerTranslation: Float = 0f
 
     /**
      * The upper translation limit, usually in meters.
      */
-
     var upperTranslation: Float = 0f
 
     /**
      * Enable/disable the joint motor.
      */
-
     var enableMotor: Boolean = false
 
     /**
      * The maximum motor torque, usually in N-m.
      */
-
     var maxMotorForce: Float = 0f
 
     /**
      * The desired motor speed in radians per second.
      */
-
     var motorSpeed: Float = 0f
 
     /**

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/PulleyJointDef.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/PulleyJointDef.kt
@@ -42,43 +42,36 @@ class PulleyJointDef : JointDef(JointType.PULLEY) {
     /**
      * The first ground anchor in world coordinates. This point never moves.
      */
-
     var groundAnchorA: Vec2 = Vec2(-1.0f, 1.0f)
 
     /**
      * The second ground anchor in world coordinates. This point never moves.
      */
-
     var groundAnchorB: Vec2 = Vec2(1.0f, 1.0f)
 
     /**
      * The local anchor point relative to bodyA's origin.
      */
-
     var localAnchorA: Vec2 = Vec2(-1.0f, 0.0f)
 
     /**
      * The local anchor point relative to bodyB's origin.
      */
-
     var localAnchorB: Vec2 = Vec2(1.0f, 0.0f)
 
     /**
      * The a reference length for the segment attached to bodyA.
      */
-
     var lengthA: Float = 0f
 
     /**
      * The a reference length for the segment attached to bodyB.
      */
-
     var lengthB: Float = 0f
 
     /**
      * The pulley ratio, used to simulate a block-and-tackle.
      */
-
     var ratio: Float = 1f
 
     init {

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/RevoluteJoint.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/RevoluteJoint.kt
@@ -34,19 +34,6 @@ import org.jbox2d.dynamics.SolverData
 import org.jbox2d.internal.*
 import org.jbox2d.pooling.IWorldPool
 
-//Point-to-point constraint
-//C = p2 - p1
-//Cdot = v2 - v1
-//   = v2 + cross(w2, r2) - v1 - cross(w1, r1)
-//J = [-I -r1_skew I r2_skew ]
-//Identity used:
-//w k % (rx i + ry j) = w * (-ry i + rx j)
-
-//Motor constraint
-//Cdot = w2 - w1
-//J = [0 0 -1 0 0 1]
-//K = invI1 + invI2
-
 /**
  * A revolute joint constrains two bodies to share a common point while they are free to rotate
  * about the point. The relative rotation about the shared point is the joint angle. You can limit
@@ -59,117 +46,98 @@ import org.jbox2d.pooling.IWorldPool
 class RevoluteJoint(argWorld: IWorldPool, def: RevoluteJointDef) : Joint(argWorld, def) {
 
     // Solver shared
+    val localAnchorA = Vec2().set(def.localAnchorA)
+    val localAnchorB = Vec2().set(def.localAnchorB)
+    private val impulse = Vec3()
+    private var motorImpulse: Float = 0f
 
-    val m_localAnchorA = Vec2()
-
-    val m_localAnchorB = Vec2()
-    private val m_impulse = Vec3()
-    private var m_motorImpulse: Float = 0.toFloat()
-
-    var isMotorEnabled: Boolean = false
+    var isMotorEnabled: Boolean = def.enableMotor
         private set
-    private var m_maxMotorTorque: Float = 0.toFloat()
-    private var m_motorSpeed: Float = 0.toFloat()
+    private var _maxMotorTorque: Float = def.maxMotorTorque
+    private var _motorSpeed: Float = def.motorSpeed
 
-    var isLimitEnabled: Boolean = false
+    var isLimitEnabled: Boolean = def.enableLimit
         private set
-    var m_referenceAngleRadians: Float = 0.toFloat()
+    var referenceAngleRadians: Float = def.referenceAngleRadians
         protected set
-    var m_referenceAngleDegrees: Float
-        protected set(value) = run { m_referenceAngleRadians = value * MathUtils.DEG2RAD }
-        get() = m_referenceAngleRadians * MathUtils.RAD2DEG
-    var m_referenceAngle: Angle
-        protected set(value) = run { m_referenceAngleRadians = value.radians.toFloat() }
-        get() = m_referenceAngleRadians.radians
-    var lowerLimit: Float = 0.toFloat()
+    var referenceAngleDegrees: Float
+        get() = referenceAngleRadians * MathUtils.RAD2DEG
+        protected set(value) = run { referenceAngleRadians = value * MathUtils.DEG2RAD }
+    var referenceAngle: Angle
+        get() = referenceAngleRadians.radians
+        protected set(value) = run { referenceAngleRadians = value.radians.toFloat() }
+    var lowerLimit: Float = def.lowerAngleRadians
         private set
-    var upperLimit: Float = 0.toFloat()
+    var upperLimit: Float = def.upperAngleRadians
         private set
 
     // Solver temp
-    private var m_indexA: Int = 0
-    private var m_indexB: Int = 0
-    private val m_rA = Vec2()
-    private val m_rB = Vec2()
-    private val m_localCenterA = Vec2()
-    private val m_localCenterB = Vec2()
-    private var m_invMassA: Float = 0.toFloat()
-    private var m_invMassB: Float = 0.toFloat()
-    private var m_invIA: Float = 0.toFloat()
-    private var m_invIB: Float = 0.toFloat()
-    private val m_mass = Mat33() // effective mass for point-to-point constraint.
-    private var m_motorMass: Float = 0.toFloat() // effective mass for motor/limit angular constraint.
-    private var m_limitState: LimitState? = null
+    private var indexA: Int = 0
+    private var indexB: Int = 0
+    private val rA = Vec2()
+    private val rB = Vec2()
+    private val localCenterA = Vec2()
+    private val localCenterB = Vec2()
+    private var invMassA: Float = 0f
+    private var invMassB: Float = 0f
+    private var invIA: Float = 0f
+    private var invIB: Float = 0f
+    private val mass = Mat33() // effective mass for point-to-point constraint.
+    private var motorMass: Float = 0f // effective mass for motor/limit angular constraint.
+    private var limitState: LimitState = LimitState.INACTIVE
 
     val jointAngleRadians: Float
         get() {
-            val b1 = m_bodyA
-            val b2 = m_bodyB
-            return b2!!.m_sweep.a - b1!!.m_sweep.a - m_referenceAngleRadians
+            val b1 = bodyA
+            val b2 = bodyB
+            return b2!!.sweep.a - b1!!.sweep.a - referenceAngleRadians
         }
 
     val jointAngleDegrees: Float get() = jointAngleRadians * MathUtils.RAD2DEG
-
     val jointAngle: Angle get() = jointAngleRadians.radians
 
     val jointSpeed: Float
         get() {
-            val b1 = m_bodyA
-            val b2 = m_bodyB
-            return b2!!.m_angularVelocity - b1!!.m_angularVelocity
+            val b1 = bodyA
+            val b2 = bodyB
+            return b2!!._angularVelocity - b1!!._angularVelocity
         }
 
     var motorSpeed: Float
-        get() = m_motorSpeed
+        get() = _motorSpeed
         set(speed) {
-            m_bodyA!!.isAwake = true
-            m_bodyB!!.isAwake = true
-            m_motorSpeed = speed
+            bodyA!!.isAwake = true
+            bodyB!!.isAwake = true
+            _motorSpeed = speed
         }
 
     var maxMotorTorque: Float
-        get() = m_maxMotorTorque
+        get() = _maxMotorTorque
         set(torque) {
-            m_bodyA!!.isAwake = true
-            m_bodyB!!.isAwake = true
-            m_maxMotorTorque = torque
+            bodyA!!.isAwake = true
+            bodyB!!.isAwake = true
+            _maxMotorTorque = torque
         }
 
-    init {
-        m_localAnchorA.set(def.localAnchorA)
-        m_localAnchorB.set(def.localAnchorB)
-        m_referenceAngleRadians = def.referenceAngleRadians
-
-        m_motorImpulse = 0f
-
-        lowerLimit = def.lowerAngleRadians
-        upperLimit = def.upperAngleRadians
-        m_maxMotorTorque = def.maxMotorTorque
-        m_motorSpeed = def.motorSpeed
-        isLimitEnabled = def.enableLimit
-        isMotorEnabled = def.enableMotor
-        m_limitState = LimitState.INACTIVE
-    }
-
     override fun initVelocityConstraints(data: SolverData) {
-        m_indexA = m_bodyA!!.m_islandIndex
-        m_indexB = m_bodyB!!.m_islandIndex
-        m_localCenterA.set(m_bodyA!!.m_sweep.localCenter)
-        m_localCenterB.set(m_bodyB!!.m_sweep.localCenter)
-        m_invMassA = m_bodyA!!.m_invMass
-        m_invMassB = m_bodyB!!.m_invMass
-        m_invIA = m_bodyA!!.m_invI
-        m_invIB = m_bodyB!!.m_invI
+        indexA = bodyA!!.islandIndex
+        indexB = bodyB!!.islandIndex
+        localCenterA.set(bodyA!!.sweep.localCenter)
+        localCenterB.set(bodyB!!.sweep.localCenter)
+        invMassA = bodyA!!.invMass
+        invMassB = bodyB!!.invMass
+        invIA = bodyA!!.invI
+        invIB = bodyB!!.invI
 
         // Vec2 cA = data.positions[m_indexA].c;
-        val aA = data.positions!![m_indexA].a
-        val vA = data.velocities!![m_indexA].v
-        var wA = data.velocities!![m_indexA].w
+        val aA = data.positions!![indexA].a
+        val vA = data.velocities!![indexA].v
+        var wA = data.velocities!![indexA].w
 
         // Vec2 cB = data.positions[m_indexB].c;
-        val aB = data.positions!![m_indexB].a
-        val vB = data.velocities!![m_indexB].v
-        var wB = data.velocities!![m_indexB].w
+        val aB = data.positions!![indexB].a
+        val vB = data.velocities!![indexB].v
+        var wB = data.velocities!![indexB].w
         val qA = pool.popRot()
         val qB = pool.popRot()
         val temp = pool.popVec2()
@@ -178,8 +146,8 @@ class RevoluteJoint(argWorld: IWorldPool, def: RevoluteJointDef) : Joint(argWorl
         qB.setRadians(aB)
 
         // Compute the effective masses.
-        Rot.mulToOutUnsafe(qA, temp.set(m_localAnchorA).subLocal(m_localCenterA), m_rA)
-        Rot.mulToOutUnsafe(qB, temp.set(m_localAnchorB).subLocal(m_localCenterB), m_rB)
+        Rot.mulToOutUnsafe(qA, temp.set(localAnchorA).subLocal(localCenterA), rA)
+        Rot.mulToOutUnsafe(qB, temp.set(localAnchorB).subLocal(localCenterB), rB)
 
         // J = [-I -r1_skew I r2_skew]
         // [ 0 -1 0 1]
@@ -190,106 +158,104 @@ class RevoluteJoint(argWorld: IWorldPool, def: RevoluteJointDef) : Joint(argWorl
         // [ -r1y*iA*r1x-r2y*iB*r2x, mA+r1x^2*iA+mB+r2x^2*iB, r1x*iA+r2x*iB]
         // [ -r1y*iA-r2y*iB, r1x*iA+r2x*iB, iA+iB]
 
-        val mA = m_invMassA
-        val mB = m_invMassB
-        val iA = m_invIA
-        val iB = m_invIB
+        val mA = invMassA
+        val mB = invMassB
+        val iA = invIA
+        val iB = invIB
 
         val fixedRotation = iA + iB == 0.0f
 
-        m_mass.ex.x = mA + mB + m_rA.y * m_rA.y * iA + m_rB.y * m_rB.y * iB
-        m_mass.ey.x = -m_rA.y * m_rA.x * iA - m_rB.y * m_rB.x * iB
-        m_mass.ez.x = -m_rA.y * iA - m_rB.y * iB
-        m_mass.ex.y = m_mass.ey.x
-        m_mass.ey.y = mA + mB + m_rA.x * m_rA.x * iA + m_rB.x * m_rB.x * iB
-        m_mass.ez.y = m_rA.x * iA + m_rB.x * iB
-        m_mass.ex.z = m_mass.ez.x
-        m_mass.ey.z = m_mass.ez.y
-        m_mass.ez.z = iA + iB
+        mass.ex.x = mA + mB + rA.y * rA.y * iA + rB.y * rB.y * iB
+        mass.ey.x = -rA.y * rA.x * iA - rB.y * rB.x * iB
+        mass.ez.x = -rA.y * iA - rB.y * iB
+        mass.ex.y = mass.ey.x
+        mass.ey.y = mA + mB + rA.x * rA.x * iA + rB.x * rB.x * iB
+        mass.ez.y = rA.x * iA + rB.x * iB
+        mass.ex.z = mass.ez.x
+        mass.ey.z = mass.ez.y
+        mass.ez.z = iA + iB
 
-        m_motorMass = iA + iB
-        if (m_motorMass > 0.0f) {
-            m_motorMass = 1.0f / m_motorMass
+        motorMass = iA + iB
+        if (motorMass > 0.0f) {
+            motorMass = 1.0f / motorMass
         }
 
-        if (isMotorEnabled == false || fixedRotation) {
-            m_motorImpulse = 0.0f
+        if (!isMotorEnabled || fixedRotation) {
+            motorImpulse = 0.0f
         }
 
-        if (isLimitEnabled && fixedRotation == false) {
-            val jointAngle = aB - aA - m_referenceAngleRadians
+        if (isLimitEnabled && !fixedRotation) {
+            val jointAngle = aB - aA - referenceAngleRadians
             if (MathUtils.abs(upperLimit - lowerLimit) < 2.0f * Settings.angularSlop) {
-                m_limitState = LimitState.EQUAL
+                limitState = LimitState.EQUAL
             } else if (jointAngle <= lowerLimit) {
-                if (m_limitState !== LimitState.AT_LOWER) {
-                    m_impulse.z = 0.0f
+                if (limitState !== LimitState.AT_LOWER) {
+                    impulse.z = 0.0f
                 }
-                m_limitState = LimitState.AT_LOWER
+                limitState = LimitState.AT_LOWER
             } else if (jointAngle >= upperLimit) {
-                if (m_limitState !== LimitState.AT_UPPER) {
-                    m_impulse.z = 0.0f
+                if (limitState !== LimitState.AT_UPPER) {
+                    impulse.z = 0.0f
                 }
-                m_limitState = LimitState.AT_UPPER
+                limitState = LimitState.AT_UPPER
             } else {
-                m_limitState = LimitState.INACTIVE
-                m_impulse.z = 0.0f
+                limitState = LimitState.INACTIVE
+                impulse.z = 0.0f
             }
         } else {
-            m_limitState = LimitState.INACTIVE
+            limitState = LimitState.INACTIVE
         }
 
         if (data.step!!.warmStarting) {
             val P = pool.popVec2()
             // Scale impulses to support a variable time step.
-            m_impulse.x *= data.step!!.dtRatio
-            m_impulse.y *= data.step!!.dtRatio
-            m_motorImpulse *= data.step!!.dtRatio
+            impulse.x *= data.step!!.dtRatio
+            impulse.y *= data.step!!.dtRatio
+            motorImpulse *= data.step!!.dtRatio
 
-            P.x = m_impulse.x
-            P.y = m_impulse.y
+            P.x = impulse.x
+            P.y = impulse.y
 
             vA.x -= mA * P.x
             vA.y -= mA * P.y
-            wA -= iA * (Vec2.cross(m_rA, P) + m_motorImpulse + m_impulse.z)
+            wA -= iA * (Vec2.cross(rA, P) + motorImpulse + impulse.z)
 
             vB.x += mB * P.x
             vB.y += mB * P.y
-            wB += iB * (Vec2.cross(m_rB, P) + m_motorImpulse + m_impulse.z)
+            wB += iB * (Vec2.cross(rB, P) + motorImpulse + impulse.z)
             pool.pushVec2(1)
         } else {
-            m_impulse.setZero()
-            m_motorImpulse = 0.0f
+            impulse.setZero()
+            motorImpulse = 0.0f
         }
-        // data.velocities[m_indexA].v.set(vA);
-        data.velocities!![m_indexA].w = wA
-        // data.velocities[m_indexB].v.set(vB);
-        data.velocities!![m_indexB].w = wB
+        data.velocities!![indexA].w = wA
+        data.velocities!![indexB].w = wB
 
         pool.pushVec2(1)
         pool.pushRot(2)
     }
 
     override fun solveVelocityConstraints(data: SolverData) {
-        val vA = data.velocities!![m_indexA].v
-        var wA = data.velocities!![m_indexA].w
-        val vB = data.velocities!![m_indexB].v
-        var wB = data.velocities!![m_indexB].w
+        val vA = data.velocities!![indexA].v
+        var wA = data.velocities!![indexA].w
+        val vB = data.velocities!![indexB].v
+        var wB = data.velocities!![indexB].w
 
-        val mA = m_invMassA
-        val mB = m_invMassB
-        val iA = m_invIA
-        val iB = m_invIB
+        val mA = invMassA
+        val mB = invMassB
+        val iA = invIA
+        val iB = invIB
 
         val fixedRotation = iA + iB == 0.0f
 
         // Solve motor constraint.
-        if (isMotorEnabled && m_limitState !== LimitState.EQUAL && fixedRotation == false) {
-            val Cdot = wB - wA - m_motorSpeed
-            var impulse = -m_motorMass * Cdot
-            val oldImpulse = m_motorImpulse
-            val maxImpulse = data.step!!.dt * m_maxMotorTorque
-            m_motorImpulse = MathUtils.clamp(m_motorImpulse + impulse, -maxImpulse, maxImpulse)
-            impulse = m_motorImpulse - oldImpulse
+        if (isMotorEnabled && limitState !== LimitState.EQUAL && !fixedRotation) {
+            val Cdot = wB - wA - _motorSpeed
+            var impulse = -motorMass * Cdot
+            val oldImpulse = motorImpulse
+            val maxImpulse = data.step!!.dt * _maxMotorTorque
+            motorImpulse = MathUtils.clamp(motorImpulse + impulse, -maxImpulse, maxImpulse)
+            impulse = motorImpulse - oldImpulse
 
             wA -= iA * impulse
             wB += iB * impulse
@@ -297,55 +263,55 @@ class RevoluteJoint(argWorld: IWorldPool, def: RevoluteJointDef) : Joint(argWorl
         val temp = pool.popVec2()
 
         // Solve limit constraint.
-        if (isLimitEnabled && m_limitState !== LimitState.INACTIVE && fixedRotation == false) {
+        if (isLimitEnabled && limitState !== LimitState.INACTIVE && !fixedRotation) {
 
             val Cdot1 = pool.popVec2()
             val Cdot = pool.popVec3()
 
             // Solve point-to-point constraint
-            Vec2.crossToOutUnsafe(wA, m_rA, temp)
-            Vec2.crossToOutUnsafe(wB, m_rB, Cdot1)
+            Vec2.crossToOutUnsafe(wA, rA, temp)
+            Vec2.crossToOutUnsafe(wB, rB, Cdot1)
             Cdot1.addLocal(vB).subLocal(vA).subLocal(temp)
             val Cdot2 = wB - wA
             Cdot.set(Cdot1.x, Cdot1.y, Cdot2)
 
             val impulse = pool.popVec3()
-            m_mass.solve33ToOut(Cdot, impulse)
+            mass.solve33ToOut(Cdot, impulse)
             impulse.negateLocal()
 
-            if (m_limitState === LimitState.EQUAL) {
-                m_impulse.addLocal(impulse)
-            } else if (m_limitState === LimitState.AT_LOWER) {
-                val newImpulse = m_impulse.z + impulse.z
+            if (limitState === LimitState.EQUAL) {
+                this.impulse.addLocal(impulse)
+            } else if (limitState === LimitState.AT_LOWER) {
+                val newImpulse = this.impulse.z + impulse.z
                 if (newImpulse < 0.0f) {
                     val rhs = pool.popVec2()
-                    rhs.set(m_mass.ez.x, m_mass.ez.y).mulLocal(m_impulse.z).subLocal(Cdot1)
-                    m_mass.solve22ToOut(rhs, temp)
+                    rhs.set(mass.ez.x, mass.ez.y).mulLocal(this.impulse.z).subLocal(Cdot1)
+                    mass.solve22ToOut(rhs, temp)
                     impulse.x = temp.x
                     impulse.y = temp.y
-                    impulse.z = -m_impulse.z
-                    m_impulse.x += temp.x
-                    m_impulse.y += temp.y
-                    m_impulse.z = 0.0f
+                    impulse.z = -this.impulse.z
+                    this.impulse.x += temp.x
+                    this.impulse.y += temp.y
+                    this.impulse.z = 0.0f
                     pool.pushVec2(1)
                 } else {
-                    m_impulse.addLocal(impulse)
+                    this.impulse.addLocal(impulse)
                 }
-            } else if (m_limitState === LimitState.AT_UPPER) {
-                val newImpulse = m_impulse.z + impulse.z
+            } else if (limitState === LimitState.AT_UPPER) {
+                val newImpulse = this.impulse.z + impulse.z
                 if (newImpulse > 0.0f) {
                     val rhs = pool.popVec2()
-                    rhs.set(m_mass.ez.x, m_mass.ez.y).mulLocal(m_impulse.z).subLocal(Cdot1)
-                    m_mass.solve22ToOut(rhs, temp)
+                    rhs.set(mass.ez.x, mass.ez.y).mulLocal(this.impulse.z).subLocal(Cdot1)
+                    mass.solve22ToOut(rhs, temp)
                     impulse.x = temp.x
                     impulse.y = temp.y
-                    impulse.z = -m_impulse.z
-                    m_impulse.x += temp.x
-                    m_impulse.y += temp.y
-                    m_impulse.z = 0.0f
+                    impulse.z = -this.impulse.z
+                    this.impulse.x += temp.x
+                    this.impulse.y += temp.y
+                    this.impulse.z = 0.0f
                     pool.pushVec2(1)
                 } else {
-                    m_impulse.addLocal(impulse)
+                    this.impulse.addLocal(impulse)
                 }
             }
             val P = pool.popVec2()
@@ -354,11 +320,11 @@ class RevoluteJoint(argWorld: IWorldPool, def: RevoluteJointDef) : Joint(argWorl
 
             vA.x -= mA * P.x
             vA.y -= mA * P.y
-            wA -= iA * (Vec2.cross(m_rA, P) + impulse.z)
+            wA -= iA * (Vec2.cross(rA, P) + impulse.z)
 
             vB.x += mB * P.x
             vB.y += mB * P.y
-            wB += iB * (Vec2.cross(m_rB, P) + impulse.z)
+            wB += iB * (Vec2.cross(rB, P) + impulse.z)
 
             pool.pushVec2(2)
             pool.pushVec3(2)
@@ -368,29 +334,27 @@ class RevoluteJoint(argWorld: IWorldPool, def: RevoluteJointDef) : Joint(argWorl
             val Cdot = pool.popVec2()
             val impulse = pool.popVec2()
 
-            Vec2.crossToOutUnsafe(wA, m_rA, temp)
-            Vec2.crossToOutUnsafe(wB, m_rB, Cdot)
+            Vec2.crossToOutUnsafe(wA, rA, temp)
+            Vec2.crossToOutUnsafe(wB, rB, Cdot)
             Cdot.addLocal(vB).subLocal(vA).subLocal(temp)
-            m_mass.solve22ToOut(Cdot.negateLocal(), impulse) // just leave negated
+            mass.solve22ToOut(Cdot.negateLocal(), impulse) // just leave negated
 
-            m_impulse.x += impulse.x
-            m_impulse.y += impulse.y
+            this.impulse.x += impulse.x
+            this.impulse.y += impulse.y
 
             vA.x -= mA * impulse.x
             vA.y -= mA * impulse.y
-            wA -= iA * Vec2.cross(m_rA, impulse)
+            wA -= iA * Vec2.cross(rA, impulse)
 
             vB.x += mB * impulse.x
             vB.y += mB * impulse.y
-            wB += iB * Vec2.cross(m_rB, impulse)
+            wB += iB * Vec2.cross(rB, impulse)
 
             pool.pushVec2(2)
         }
 
-        // data.velocities[m_indexA].v.set(vA);
-        data.velocities!![m_indexA].w = wA
-        // data.velocities[m_indexB].v.set(vB);
-        data.velocities!![m_indexB].w = wB
+        data.velocities!![indexA].w = wA
+        data.velocities!![indexB].w = wB
 
         pool.pushVec2(1)
     }
@@ -398,10 +362,10 @@ class RevoluteJoint(argWorld: IWorldPool, def: RevoluteJointDef) : Joint(argWorl
     override fun solvePositionConstraints(data: SolverData): Boolean {
         val qA = pool.popRot()
         val qB = pool.popRot()
-        val cA = data.positions!![m_indexA].c
-        var aA = data.positions!![m_indexA].a
-        val cB = data.positions!![m_indexB].c
-        var aB = data.positions!![m_indexB].a
+        val cA = data.positions!![indexA].c
+        var aA = data.positions!![indexA].a
+        val cB = data.positions!![indexB].c
+        var aB = data.positions!![indexB].a
 
         qA.setRadians(aA)
         qB.setRadians(aB)
@@ -409,37 +373,37 @@ class RevoluteJoint(argWorld: IWorldPool, def: RevoluteJointDef) : Joint(argWorl
         var angularError = 0.0f
         var positionError = 0.0f
 
-        val fixedRotation = m_invIA + m_invIB == 0.0f
+        val fixedRotation = invIA + invIB == 0.0f
 
         // Solve angular limit constraint.
-        if (isLimitEnabled && m_limitState !== LimitState.INACTIVE && fixedRotation == false) {
-            val angle = aB - aA - m_referenceAngleRadians
+        if (isLimitEnabled && limitState !== LimitState.INACTIVE && !fixedRotation) {
+            val angle = aB - aA - referenceAngleRadians
             var limitImpulse = 0.0f
 
-            if (m_limitState === LimitState.EQUAL) {
+            if (limitState === LimitState.EQUAL) {
                 // Prevent large angular corrections
                 val C = MathUtils.clamp(angle - lowerLimit, -Settings.maxAngularCorrection,
                         Settings.maxAngularCorrection)
-                limitImpulse = -m_motorMass * C
+                limitImpulse = -motorMass * C
                 angularError = MathUtils.abs(C)
-            } else if (m_limitState === LimitState.AT_LOWER) {
+            } else if (limitState === LimitState.AT_LOWER) {
                 var C = angle - lowerLimit
                 angularError = -C
 
                 // Prevent large angular corrections and allow some slop.
                 C = MathUtils.clamp(C + Settings.angularSlop, -Settings.maxAngularCorrection, 0.0f)
-                limitImpulse = -m_motorMass * C
-            } else if (m_limitState === LimitState.AT_UPPER) {
+                limitImpulse = -motorMass * C
+            } else if (limitState === LimitState.AT_UPPER) {
                 var C = angle - upperLimit
                 angularError = C
 
                 // Prevent large angular corrections and allow some slop.
                 C = MathUtils.clamp(C - Settings.angularSlop, 0.0f, Settings.maxAngularCorrection)
-                limitImpulse = -m_motorMass * C
+                limitImpulse = -motorMass * C
             }
 
-            aA -= m_invIA * limitImpulse
-            aB += m_invIB * limitImpulse
+            aA -= invIA * limitImpulse
+            aB += invIB * limitImpulse
         }
         // Solve point-to-point constraint.
         run {
@@ -451,15 +415,15 @@ class RevoluteJoint(argWorld: IWorldPool, def: RevoluteJointDef) : Joint(argWorl
             val C = pool.popVec2()
             val impulse = pool.popVec2()
 
-            Rot.mulToOutUnsafe(qA, C.set(m_localAnchorA).subLocal(m_localCenterA), rA)
-            Rot.mulToOutUnsafe(qB, C.set(m_localAnchorB).subLocal(m_localCenterB), rB)
+            Rot.mulToOutUnsafe(qA, C.set(localAnchorA).subLocal(localCenterA), rA)
+            Rot.mulToOutUnsafe(qB, C.set(localAnchorB).subLocal(localCenterB), rB)
             C.set(cB).addLocal(rB).subLocal(cA).subLocal(rA)
             positionError = C.length()
 
-            val mA = m_invMassA
-            val mB = m_invMassB
-            val iA = m_invIA
-            val iB = m_invIB
+            val mA = invMassA
+            val mB = invMassB
+            val iA = invIA
+            val iB = invIB
 
             val K = pool.popMat22()
             K.ex.x = mA + mB + iA * rA.y * rA.y + iB * rB.y * rB.y
@@ -480,57 +444,55 @@ class RevoluteJoint(argWorld: IWorldPool, def: RevoluteJointDef) : Joint(argWorl
             pool.pushVec2(4)
             pool.pushMat22(1)
         }
-        // data.positions[m_indexA].c.set(cA);
-        data.positions!![m_indexA].a = aA
-        // data.positions[m_indexB].c.set(cB);
-        data.positions!![m_indexB].a = aB
+        data.positions!![indexA].a = aA
+        data.positions!![indexB].a = aB
 
         pool.pushRot(2)
 
         return positionError <= Settings.linearSlop && angularError <= Settings.angularSlop
     }
 
-    override fun getAnchorA(argOut: Vec2) {
-        m_bodyA!!.getWorldPointToOut(m_localAnchorA, argOut)
+    override fun getAnchorA(out: Vec2) {
+        bodyA!!.getWorldPointToOut(localAnchorA, out)
     }
 
-    override fun getAnchorB(argOut: Vec2) {
-        m_bodyB!!.getWorldPointToOut(m_localAnchorB, argOut)
+    override fun getAnchorB(out: Vec2) {
+        bodyB!!.getWorldPointToOut(localAnchorB, out)
     }
 
-    override fun getReactionForce(inv_dt: Float, argOut: Vec2) {
-        argOut.set(m_impulse.x, m_impulse.y).mulLocal(inv_dt)
+    override fun getReactionForce(invDt: Float, out: Vec2) {
+        out.set(impulse.x, impulse.y).mulLocal(invDt)
     }
 
-    override fun getReactionTorque(inv_dt: Float): Float {
-        return inv_dt * m_impulse.z
+    override fun getReactionTorque(invDt: Float): Float {
+        return invDt * impulse.z
     }
 
     fun enableMotor(flag: Boolean) {
-        m_bodyA!!.isAwake = true
-        m_bodyB!!.isAwake = true
+        bodyA!!.isAwake = true
+        bodyB!!.isAwake = true
         isMotorEnabled = flag
     }
 
-    fun getMotorTorque(inv_dt: Float): Float {
-        return m_motorImpulse * inv_dt
+    fun getMotorTorque(invDt: Float): Float {
+        return motorImpulse * invDt
     }
 
     fun enableLimit(flag: Boolean) {
         if (flag != isLimitEnabled) {
-            m_bodyA!!.isAwake = true
-            m_bodyB!!.isAwake = true
+            bodyA!!.isAwake = true
+            bodyB!!.isAwake = true
             isLimitEnabled = flag
-            m_impulse.z = 0.0f
+            impulse.z = 0.0f
         }
     }
 
     fun setLimits(lower: Float, upper: Float) {
         assert(lower <= upper)
         if (lower != lowerLimit || upper != upperLimit) {
-            m_bodyA!!.isAwake = true
-            m_bodyB!!.isAwake = true
-            m_impulse.z = 0.0f
+            bodyA!!.isAwake = true
+            bodyB!!.isAwake = true
+            impulse.z = 0.0f
             lowerLimit = lower
             upperLimit = upper
         }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/RevoluteJointDef.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/RevoluteJointDef.kt
@@ -59,20 +59,17 @@ import org.jbox2d.dynamics.Body
  *
  *  * you might not know where the center of mass will be.
  *  * if you add/remove shapes from a body and recompute the mass, the joints will be broken.
- *
  */
 class RevoluteJointDef : JointDef(JointType.REVOLUTE) {
 
     /**
      * The local anchor point relative to body1's origin.
      */
-
     var localAnchorA: Vec2 = Vec2(0.0f, 0.0f)
 
     /**
      * The local anchor point relative to body2's origin.
      */
-
     var localAnchorB: Vec2 = Vec2(0.0f, 0.0f)
 
     /**
@@ -97,7 +94,6 @@ class RevoluteJointDef : JointDef(JointType.REVOLUTE) {
     /**
      * A flag to enable joint limits.
      */
-
     var enableLimit: Boolean = false
 
     /** The lower angle for the joint limit (radians). */
@@ -129,27 +125,20 @@ class RevoluteJointDef : JointDef(JointType.REVOLUTE) {
     /**
      * A flag to enable the joint motor.
      */
-
     var enableMotor: Boolean = false
 
     /**
      * The desired motor speed. Usually in radians per second.
      */
-
     var motorSpeed: Float = 0f
 
     /**
      * The maximum motor torque used to achieve the desired motor speed. Usually in N-m.
      */
-
     var maxMotorTorque: Float = 0f
 
     /**
      * Initialize the bodies, anchors, and reference angle using the world anchor.
-     *
-     * @param b1
-     * @param b2
-     * @param anchor
      */
     fun initialize(b1: Body, b2: Body, anchor: Vec2) {
         bodyA = b1

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/RopeJoint.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/RopeJoint.kt
@@ -17,63 +17,49 @@ import org.jbox2d.pooling.IWorldPool
  * @author Daniel Murphy
  */
 class RopeJoint(worldPool: IWorldPool, def: RopeJointDef) : Joint(worldPool, def) {
+
     // Solver shared
-
-    val localAnchorA = Vec2()
-
-    val localAnchorB = Vec2()
-
-    var maxLength: Float = 0.toFloat()
-    private var m_length: Float = 0.toFloat()
-    private var m_impulse: Float = 0.toFloat()
+    val localAnchorA = Vec2().set(def.localAnchorA)
+    val localAnchorB = Vec2().set(def.localAnchorB)
+    var maxLength: Float = def.maxLength
+    private var length: Float = 0f
+    private var impulse: Float = 0f
 
     // Solver temp
-    private var m_indexA: Int = 0
-    private var m_indexB: Int = 0
-    private val m_u = Vec2()
-    private val m_rA = Vec2()
-    private val m_rB = Vec2()
-    private val m_localCenterA = Vec2()
-    private val m_localCenterB = Vec2()
-    private var m_invMassA: Float = 0.toFloat()
-    private var m_invMassB: Float = 0.toFloat()
-    private var m_invIA: Float = 0.toFloat()
-    private var m_invIB: Float = 0.toFloat()
-    private var m_mass: Float = 0.toFloat()
-    var limitState: LimitState? = null
+    private var indexA: Int = 0
+    private var indexB: Int = 0
+    private val u = Vec2()
+    private val rA = Vec2()
+    private val rB = Vec2()
+    private val localCenterA = Vec2()
+    private val localCenterB = Vec2()
+    private var invMassA: Float = 0f
+    private var invMassB: Float = 0f
+    private var invIA: Float = 0f
+    private var invIB: Float = 0f
+    private var mass: Float = 0f
+    var limitState: LimitState = LimitState.INACTIVE
         private set
 
-    init {
-        localAnchorA.set(def.localAnchorA)
-        localAnchorB.set(def.localAnchorB)
-
-        maxLength = def.maxLength
-
-        m_mass = 0.0f
-        m_impulse = 0.0f
-        limitState = LimitState.INACTIVE
-        m_length = 0.0f
-    }
-
     override fun initVelocityConstraints(data: SolverData) {
-        m_indexA = m_bodyA!!.m_islandIndex
-        m_indexB = m_bodyB!!.m_islandIndex
-        m_localCenterA.set(m_bodyA!!.m_sweep.localCenter)
-        m_localCenterB.set(m_bodyB!!.m_sweep.localCenter)
-        m_invMassA = m_bodyA!!.m_invMass
-        m_invMassB = m_bodyB!!.m_invMass
-        m_invIA = m_bodyA!!.m_invI
-        m_invIB = m_bodyB!!.m_invI
+        indexA = bodyA!!.islandIndex
+        indexB = bodyB!!.islandIndex
+        localCenterA.set(bodyA!!.sweep.localCenter)
+        localCenterB.set(bodyB!!.sweep.localCenter)
+        invMassA = bodyA!!.invMass
+        invMassB = bodyB!!.invMass
+        invIA = bodyA!!.invI
+        invIB = bodyB!!.invI
 
-        val cA = data.positions!![m_indexA].c
-        val aA = data.positions!![m_indexA].a
-        val vA = data.velocities!![m_indexA].v
-        var wA = data.velocities!![m_indexA].w
+        val cA = data.positions!![indexA].c
+        val aA = data.positions!![indexA].a
+        val vA = data.velocities!![indexA].v
+        var wA = data.velocities!![indexA].w
 
-        val cB = data.positions!![m_indexB].c
-        val aB = data.positions!![m_indexB].a
-        val vB = data.velocities!![m_indexB].v
-        var wB = data.velocities!![m_indexB].w
+        val cB = data.positions!![indexB].c
+        val aB = data.positions!![indexB].a
+        val vB = data.velocities!![indexB].v
+        var wB = data.velocities!![indexB].w
 
         val qA = pool.popRot()
         val qB = pool.popRot()
@@ -83,115 +69,107 @@ class RopeJoint(worldPool: IWorldPool, def: RopeJointDef) : Joint(worldPool, def
         qB.setRadians(aB)
 
         // Compute the effective masses.
-        Rot.mulToOutUnsafe(qA, temp.set(localAnchorA).subLocal(m_localCenterA), m_rA)
-        Rot.mulToOutUnsafe(qB, temp.set(localAnchorB).subLocal(m_localCenterB), m_rB)
+        Rot.mulToOutUnsafe(qA, temp.set(localAnchorA).subLocal(localCenterA), rA)
+        Rot.mulToOutUnsafe(qB, temp.set(localAnchorB).subLocal(localCenterB), rB)
 
-        m_u.set(cB).addLocal(m_rB).subLocal(cA).subLocal(m_rA)
+        u.set(cB).addLocal(rB).subLocal(cA).subLocal(rA)
 
-        m_length = m_u.length()
+        length = u.length()
 
-        val C = m_length - maxLength
-        if (C > 0.0f) {
-            limitState = LimitState.AT_UPPER
+        val C = length - maxLength
+        limitState = if (C > 0.0f) LimitState.AT_UPPER else LimitState.INACTIVE
+
+        if (length > Settings.linearSlop) {
+            u.mulLocal(1.0f / length)
         } else {
-            limitState = LimitState.INACTIVE
-        }
-
-        if (m_length > Settings.linearSlop) {
-            m_u.mulLocal(1.0f / m_length)
-        } else {
-            m_u.setZero()
-            m_mass = 0.0f
-            m_impulse = 0.0f
+            u.setZero()
+            mass = 0.0f
+            impulse = 0.0f
             pool.pushRot(2)
             pool.pushVec2(1)
             return
         }
 
         // Compute effective mass.
-        val crA = Vec2.cross(m_rA, m_u)
-        val crB = Vec2.cross(m_rB, m_u)
-        val invMass = m_invMassA + m_invIA * crA * crA + m_invMassB + m_invIB * crB * crB
+        val crA = Vec2.cross(rA, u)
+        val crB = Vec2.cross(rB, u)
+        val invMass = invMassA + invIA * crA * crA + invMassB + invIB * crB * crB
 
-        m_mass = if (invMass != 0.0f) 1.0f / invMass else 0.0f
+        mass = if (invMass != 0.0f) 1.0f / invMass else 0.0f
 
         if (data.step!!.warmStarting) {
             // Scale the impulse to support a variable time step.
-            m_impulse *= data.step!!.dtRatio
+            impulse *= data.step!!.dtRatio
 
-            val Px = m_impulse * m_u.x
-            val Py = m_impulse * m_u.y
-            vA.x -= m_invMassA * Px
-            vA.y -= m_invMassA * Py
-            wA -= m_invIA * (m_rA.x * Py - m_rA.y * Px)
+            val Px = impulse * u.x
+            val Py = impulse * u.y
+            vA.x -= invMassA * Px
+            vA.y -= invMassA * Py
+            wA -= invIA * (rA.x * Py - rA.y * Px)
 
-            vB.x += m_invMassB * Px
-            vB.y += m_invMassB * Py
-            wB += m_invIB * (m_rB.x * Py - m_rB.y * Px)
+            vB.x += invMassB * Px
+            vB.y += invMassB * Py
+            wB += invIB * (rB.x * Py - rB.y * Px)
         } else {
-            m_impulse = 0.0f
+            impulse = 0.0f
         }
 
         pool.pushRot(2)
         pool.pushVec2(1)
 
-        // data.velocities[m_indexA].v = vA;
-        data.velocities!![m_indexA].w = wA
-        // data.velocities[m_indexB].v = vB;
-        data.velocities!![m_indexB].w = wB
+        data.velocities!![indexA].w = wA
+        data.velocities!![indexB].w = wB
     }
 
     override fun solveVelocityConstraints(data: SolverData) {
-        val vA = data.velocities!![m_indexA].v
-        var wA = data.velocities!![m_indexA].w
-        val vB = data.velocities!![m_indexB].v
-        var wB = data.velocities!![m_indexB].w
+        val vA = data.velocities!![indexA].v
+        var wA = data.velocities!![indexA].w
+        val vB = data.velocities!![indexB].v
+        var wB = data.velocities!![indexB].w
 
         // Cdot = dot(u, v + cross(w, r))
         val vpA = pool.popVec2()
         val vpB = pool.popVec2()
         val temp = pool.popVec2()
 
-        Vec2.crossToOutUnsafe(wA, m_rA, vpA)
+        Vec2.crossToOutUnsafe(wA, rA, vpA)
         vpA.addLocal(vA)
-        Vec2.crossToOutUnsafe(wB, m_rB, vpB)
+        Vec2.crossToOutUnsafe(wB, rB, vpB)
         vpB.addLocal(vB)
 
-        val C = m_length - maxLength
-        var Cdot = Vec2.dot(m_u, temp.set(vpB).subLocal(vpA))
+        val C = length - maxLength
+        var Cdot = Vec2.dot(u, temp.set(vpB).subLocal(vpA))
 
         // Predictive constraint.
         if (C < 0.0f) {
-            Cdot += data.step!!.inv_dt * C
+            Cdot += data.step!!.invDt * C
         }
 
-        var impulse = -m_mass * Cdot
-        val oldImpulse = m_impulse
-        m_impulse = MathUtils.min(0.0f, m_impulse + impulse)
-        impulse = m_impulse - oldImpulse
+        var impulse = -mass * Cdot
+        val oldImpulse = this.impulse
+        this.impulse = MathUtils.min(0.0f, this.impulse + impulse)
+        impulse = this.impulse - oldImpulse
 
-        val Px = impulse * m_u.x
-        val Py = impulse * m_u.y
-        vA.x -= m_invMassA * Px
-        vA.y -= m_invMassA * Py
-        wA -= m_invIA * (m_rA.x * Py - m_rA.y * Px)
-        vB.x += m_invMassB * Px
-        vB.y += m_invMassB * Py
-        wB += m_invIB * (m_rB.x * Py - m_rB.y * Px)
+        val Px = impulse * u.x
+        val Py = impulse * u.y
+        vA.x -= invMassA * Px
+        vA.y -= invMassA * Py
+        wA -= invIA * (rA.x * Py - rA.y * Px)
+        vB.x += invMassB * Px
+        vB.y += invMassB * Py
+        wB += invIB * (rB.x * Py - rB.y * Px)
 
         pool.pushVec2(3)
 
-        // data.velocities[m_indexA].v = vA;
-        data.velocities!![m_indexA].w = wA
-        // data.velocities[m_indexB].v = vB;
-        data.velocities!![m_indexB].w = wB
+        data.velocities!![indexA].w = wA
+        data.velocities!![indexB].w = wB
     }
 
     override fun solvePositionConstraints(data: SolverData): Boolean {
-        val cA = data.positions!![m_indexA].c
-        var aA = data.positions!![m_indexA].a
-        val cB = data.positions!![m_indexB].c
-        var aB = data.positions!![m_indexB].a
+        val cA = data.positions!![indexA].c
+        var aA = data.positions!![indexA].a
+        val cB = data.positions!![indexB].c
+        var aB = data.positions!![indexB].a
 
         val qA = pool.popRot()
         val qB = pool.popRot()
@@ -204,8 +182,8 @@ class RopeJoint(worldPool: IWorldPool, def: RopeJointDef) : Joint(worldPool, def
         qB.setRadians(aB)
 
         // Compute the effective masses.
-        Rot.mulToOutUnsafe(qA, temp.set(localAnchorA).subLocal(m_localCenterA), rA)
-        Rot.mulToOutUnsafe(qB, temp.set(localAnchorB).subLocal(m_localCenterB), rB)
+        Rot.mulToOutUnsafe(qA, temp.set(localAnchorA).subLocal(localCenterA), rA)
+        Rot.mulToOutUnsafe(qB, temp.set(localAnchorB).subLocal(localCenterB), rB)
         u.set(cB).addLocal(rB).subLocal(cA).subLocal(rA)
 
         val length = u.normalize()
@@ -213,42 +191,37 @@ class RopeJoint(worldPool: IWorldPool, def: RopeJointDef) : Joint(worldPool, def
 
         C = MathUtils.clamp(C, 0.0f, Settings.maxLinearCorrection)
 
-        val impulse = -m_mass * C
+        val impulse = -mass * C
         val Px = impulse * u.x
         val Py = impulse * u.y
 
-        cA.x -= m_invMassA * Px
-        cA.y -= m_invMassA * Py
-        aA -= m_invIA * (rA.x * Py - rA.y * Px)
-        cB.x += m_invMassB * Px
-        cB.y += m_invMassB * Py
-        aB += m_invIB * (rB.x * Py - rB.y * Px)
+        cA.x -= invMassA * Px
+        cA.y -= invMassA * Py
+        aA -= invIA * (rA.x * Py - rA.y * Px)
+        cB.x += invMassB * Px
+        cB.y += invMassB * Py
+        aB += invIB * (rB.x * Py - rB.y * Px)
 
         pool.pushRot(2)
         pool.pushVec2(4)
 
-        // data.positions[m_indexA].c = cA;
-        data.positions!![m_indexA].a = aA
-        // data.positions[m_indexB].c = cB;
-        data.positions!![m_indexB].a = aB
+        data.positions!![indexA].a = aA
+        data.positions!![indexB].a = aB
 
         return length - maxLength < Settings.linearSlop
     }
 
-    override fun getAnchorA(argOut: Vec2) {
-        m_bodyA!!.getWorldPointToOut(localAnchorA, argOut)
+    override fun getAnchorA(out: Vec2) {
+        bodyA!!.getWorldPointToOut(localAnchorA, out)
     }
 
-    override fun getAnchorB(argOut: Vec2) {
-        m_bodyB!!.getWorldPointToOut(localAnchorB, argOut)
+    override fun getAnchorB(out: Vec2) {
+        bodyB!!.getWorldPointToOut(localAnchorB, out)
     }
 
-    override fun getReactionForce(inv_dt: Float, argOut: Vec2) {
-        argOut.set(m_u).mulLocal(inv_dt).mulLocal(m_impulse)
+    override fun getReactionForce(invDt: Float, out: Vec2) {
+        out.set(u).mulLocal(invDt).mulLocal(impulse)
     }
 
-    override fun getReactionTorque(inv_dt: Float): Float {
-        return 0f
-    }
-
+    override fun getReactionTorque(invDt: Float) = 0f
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/RopeJointDef.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/RopeJointDef.kt
@@ -13,19 +13,16 @@ class RopeJointDef : JointDef(JointType.ROPE) {
     /**
      * The local anchor point relative to bodyA's origin.
      */
-
     val localAnchorA = Vec2(-1f, 0f)
 
     /**
      * The local anchor point relative to bodyB's origin.
      */
-
     val localAnchorB = Vec2(1f, 0f)
 
     /**
      * The maximum length of the rope. Warning: this must be larger than b2_linearSlop or the joint
      * will have no effect.
      */
-
     var maxLength: Float = 0f
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/WeldJoint.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/WeldJoint.kt
@@ -36,20 +36,6 @@ import org.jbox2d.common.Vec3
 import org.jbox2d.dynamics.SolverData
 import org.jbox2d.pooling.IWorldPool
 
-//Point-to-point constraint
-//C = p2 - p1
-//Cdot = v2 - v1
-//   = v2 + cross(w2, r2) - v1 - cross(w1, r1)
-//J = [-I -r1_skew I r2_skew ]
-//Identity used:
-//w k % (rx i + ry j) = w * (-ry i + rx j)
-
-//Angle constraint
-//C = angle2 - angle1 - referenceAngle
-//Cdot = w2 - w1
-//J = [0 0 -1 0 0 1]
-//K = invI1 + invI2
-
 /**
  * A weld joint essentially glues two bodies together. A weld joint may distort somewhat because the
  * island constraint solver is approximate.
@@ -58,73 +44,68 @@ import org.jbox2d.pooling.IWorldPool
  */
 class WeldJoint(argWorld: IWorldPool, def: WeldJointDef) : Joint(argWorld, def) {
 
-
     var frequency: Float = def.frequencyHz
-
     var dampingRatio: Float = def.dampingRatio
-    private var m_bias: Float = 0.toFloat()
+    private var bias: Float = 0f
 
     // Solver shared
-
     val localAnchorA: Vec2 = Vec2(def.localAnchorA)
-
     val localAnchorB: Vec2 = Vec2(def.localAnchorB)
     val referenceAngleRadians: Float = def.referenceAngleRadians
     val referenceAngleDegrees: Float get() = referenceAngleRadians * MathUtils.RAD2DEG
     val referenceAngle: Angle get() = referenceAngleRadians.radians
-    private var m_gamma: Float = 0.toFloat()
-    private val m_impulse: Vec3 = Vec3(0f, 0f, 0f)
-
+    private var gamma: Float = 0f
+    private val impulse: Vec3 = Vec3(0f, 0f, 0f)
 
     // Solver temp
-    private var m_indexA: Int = 0
-    private var m_indexB: Int = 0
-    private val m_rA = Vec2()
-    private val m_rB = Vec2()
-    private val m_localCenterA = Vec2()
-    private val m_localCenterB = Vec2()
-    private var m_invMassA: Float = 0.toFloat()
-    private var m_invMassB: Float = 0.toFloat()
-    private var m_invIA: Float = 0.toFloat()
-    private var m_invIB: Float = 0.toFloat()
-    private val m_mass = Mat33()
+    private var indexA: Int = 0
+    private var indexB: Int = 0
+    private val rA = Vec2()
+    private val rB = Vec2()
+    private val localCenterA = Vec2()
+    private val localCenterB = Vec2()
+    private var invMassA: Float = 0.toFloat()
+    private var invMassB: Float = 0.toFloat()
+    private var invIA: Float = 0.toFloat()
+    private var invIB: Float = 0.toFloat()
+    private val mass = Mat33()
 
-    override fun getAnchorA(argOut: Vec2) {
-        m_bodyA!!.getWorldPointToOut(localAnchorA, argOut)
+    override fun getAnchorA(out: Vec2) {
+        bodyA!!.getWorldPointToOut(localAnchorA, out)
     }
 
-    override fun getAnchorB(argOut: Vec2) {
-        m_bodyB!!.getWorldPointToOut(localAnchorB, argOut)
+    override fun getAnchorB(out: Vec2) {
+        bodyB!!.getWorldPointToOut(localAnchorB, out)
     }
 
-    override fun getReactionForce(inv_dt: Float, argOut: Vec2) {
-        argOut.set(m_impulse.x, m_impulse.y)
-        argOut.mulLocal(inv_dt)
+    override fun getReactionForce(invDt: Float, out: Vec2) {
+        out.set(impulse.x, impulse.y)
+        out.mulLocal(invDt)
     }
 
-    override fun getReactionTorque(inv_dt: Float): Float {
-        return inv_dt * m_impulse.z
+    override fun getReactionTorque(invDt: Float): Float {
+        return invDt * impulse.z
     }
 
     override fun initVelocityConstraints(data: SolverData) {
-        m_indexA = m_bodyA!!.m_islandIndex
-        m_indexB = m_bodyB!!.m_islandIndex
-        m_localCenterA.set(m_bodyA!!.m_sweep.localCenter)
-        m_localCenterB.set(m_bodyB!!.m_sweep.localCenter)
-        m_invMassA = m_bodyA!!.m_invMass
-        m_invMassB = m_bodyB!!.m_invMass
-        m_invIA = m_bodyA!!.m_invI
-        m_invIB = m_bodyB!!.m_invI
+        indexA = bodyA!!.islandIndex
+        indexB = bodyB!!.islandIndex
+        localCenterA.set(bodyA!!.sweep.localCenter)
+        localCenterB.set(bodyB!!.sweep.localCenter)
+        invMassA = bodyA!!.invMass
+        invMassB = bodyB!!.invMass
+        invIA = bodyA!!.invI
+        invIB = bodyB!!.invI
 
         // Vec2 cA = data.positions[m_indexA].c;
-        val aA = data.positions!![m_indexA].a
-        val vA = data.velocities!![m_indexA].v
-        var wA = data.velocities!![m_indexA].w
+        val aA = data.positions!![indexA].a
+        val vA = data.velocities!![indexA].v
+        var wA = data.velocities!![indexA].w
 
         // Vec2 cB = data.positions[m_indexB].c;
-        val aB = data.positions!![m_indexB].a
-        val vB = data.velocities!![m_indexB].v
-        var wB = data.velocities!![m_indexB].w
+        val aB = data.positions!![indexB].a
+        val vB = data.velocities!![indexB].v
+        var wB = data.velocities!![indexB].w
 
         val qA = pool.popRot()
         val qB = pool.popRot()
@@ -134,8 +115,8 @@ class WeldJoint(argWorld: IWorldPool, def: WeldJointDef) : Joint(argWorld, def) 
         qB.setRadians(aB)
 
         // Compute the effective masses.
-        Rot.mulToOutUnsafe(qA, temp.set(localAnchorA).subLocal(m_localCenterA), m_rA)
-        Rot.mulToOutUnsafe(qB, temp.set(localAnchorB).subLocal(m_localCenterB), m_rB)
+        Rot.mulToOutUnsafe(qA, temp.set(localAnchorA).subLocal(localCenterA), rA)
+        Rot.mulToOutUnsafe(qB, temp.set(localAnchorB).subLocal(localCenterB), rB)
 
         // J = [-I -r1_skew I r2_skew]
         // [ 0 -1 0 1]
@@ -146,25 +127,25 @@ class WeldJoint(argWorld: IWorldPool, def: WeldJointDef) : Joint(argWorld, def) 
         // [ -r1y*iA*r1x-r2y*iB*r2x, mA+r1x^2*iA+mB+r2x^2*iB, r1x*iA+r2x*iB]
         // [ -r1y*iA-r2y*iB, r1x*iA+r2x*iB, iA+iB]
 
-        val mA = m_invMassA
-        val mB = m_invMassB
-        val iA = m_invIA
-        val iB = m_invIB
+        val mA = invMassA
+        val mB = invMassB
+        val iA = invIA
+        val iB = invIB
 
         val K = pool.popMat33()
 
-        K.ex.x = mA + mB + m_rA.y * m_rA.y * iA + m_rB.y * m_rB.y * iB
-        K.ey.x = -m_rA.y * m_rA.x * iA - m_rB.y * m_rB.x * iB
-        K.ez.x = -m_rA.y * iA - m_rB.y * iB
+        K.ex.x = mA + mB + rA.y * rA.y * iA + rB.y * rB.y * iB
+        K.ey.x = -rA.y * rA.x * iA - rB.y * rB.x * iB
+        K.ez.x = -rA.y * iA - rB.y * iB
         K.ex.y = K.ey.x
-        K.ey.y = mA + mB + m_rA.x * m_rA.x * iA + m_rB.x * m_rB.x * iB
-        K.ez.y = m_rA.x * iA + m_rB.x * iB
+        K.ey.y = mA + mB + rA.x * rA.x * iA + rB.x * rB.x * iB
+        K.ez.y = rA.x * iA + rB.x * iB
         K.ex.z = K.ez.x
         K.ey.z = K.ez.y
         K.ez.z = iA + iB
 
         if (frequency > 0.0f) {
-            K.getInverse22(m_mass)
+            K.getInverse22(mass)
 
             var invM = iA + iB
             val m = if (invM > 0.0f) 1.0f / invM else 0.0f
@@ -182,41 +163,39 @@ class WeldJoint(argWorld: IWorldPool, def: WeldJointDef) : Joint(argWorld, def) 
 
             // magic formulas
             val h = data.step!!.dt
-            m_gamma = h * (d + h * k)
-            m_gamma = if (m_gamma != 0.0f) 1.0f / m_gamma else 0.0f
-            m_bias = C * h * k * m_gamma
+            gamma = h * (d + h * k)
+            gamma = if (gamma != 0.0f) 1.0f / gamma else 0.0f
+            bias = C * h * k * gamma
 
-            invM += m_gamma
-            m_mass.ez.z = if (invM != 0.0f) 1.0f / invM else 0.0f
+            invM += gamma
+            mass.ez.z = if (invM != 0.0f) 1.0f / invM else 0.0f
         } else {
-            K.getSymInverse33(m_mass)
-            m_gamma = 0.0f
-            m_bias = 0.0f
+            K.getSymInverse33(mass)
+            gamma = 0.0f
+            bias = 0.0f
         }
 
         if (data.step!!.warmStarting) {
             val P = pool.popVec2()
             // Scale impulses to support a variable time step.
-            m_impulse.mulLocal(data.step!!.dtRatio)
+            impulse.mulLocal(data.step!!.dtRatio)
 
-            P.set(m_impulse.x, m_impulse.y)
+            P.set(impulse.x, impulse.y)
 
             vA.x -= mA * P.x
             vA.y -= mA * P.y
-            wA -= iA * (Vec2.cross(m_rA, P) + m_impulse.z)
+            wA -= iA * (Vec2.cross(rA, P) + impulse.z)
 
             vB.x += mB * P.x
             vB.y += mB * P.y
-            wB += iB * (Vec2.cross(m_rB, P) + m_impulse.z)
+            wB += iB * (Vec2.cross(rB, P) + impulse.z)
             pool.pushVec2(1)
         } else {
-            m_impulse.setZero()
+            impulse.setZero()
         }
 
-        //    data.velocities[m_indexA].v.set(vA);
-        data.velocities!![m_indexA].w = wA
-        //    data.velocities[m_indexB].v.set(vB);
-        data.velocities!![m_indexB].w = wB
+        data.velocities!![indexA].w = wA
+        data.velocities!![indexB].w = wB
 
         pool.pushVec2(1)
         pool.pushRot(2)
@@ -224,15 +203,15 @@ class WeldJoint(argWorld: IWorldPool, def: WeldJointDef) : Joint(argWorld, def) 
     }
 
     override fun solveVelocityConstraints(data: SolverData) {
-        val vA = data.velocities!![m_indexA].v
-        var wA = data.velocities!![m_indexA].w
-        val vB = data.velocities!![m_indexB].v
-        var wB = data.velocities!![m_indexB].w
+        val vA = data.velocities!![indexA].v
+        var wA = data.velocities!![indexA].w
+        val vB = data.velocities!![indexB].v
+        var wB = data.velocities!![indexB].w
 
-        val mA = m_invMassA
-        val mB = m_invMassB
-        val iA = m_invIA
-        val iB = m_invIB
+        val mA = invMassA
+        val mB = invMassB
+        val iA = invIA
+        val iB = invIB
 
         val Cdot1 = pool.popVec2()
         val P = pool.popVec2()
@@ -240,33 +219,33 @@ class WeldJoint(argWorld: IWorldPool, def: WeldJointDef) : Joint(argWorld, def) 
         if (frequency > 0.0f) {
             val Cdot2 = wB - wA
 
-            val impulse2 = -m_mass.ez.z * (Cdot2 + m_bias + m_gamma * m_impulse.z)
-            m_impulse.z += impulse2
+            val impulse2 = -mass.ez.z * (Cdot2 + bias + gamma * impulse.z)
+            impulse.z += impulse2
 
             wA -= iA * impulse2
             wB += iB * impulse2
 
-            Vec2.crossToOutUnsafe(wB, m_rB, Cdot1)
-            Vec2.crossToOutUnsafe(wA, m_rA, temp)
+            Vec2.crossToOutUnsafe(wB, rB, Cdot1)
+            Vec2.crossToOutUnsafe(wA, rA, temp)
             Cdot1.addLocal(vB).subLocal(vA).subLocal(temp)
 
             val impulse1 = P
-            Mat33.mul22ToOutUnsafe(m_mass, Cdot1, impulse1)
+            Mat33.mul22ToOutUnsafe(mass, Cdot1, impulse1)
             impulse1.negateLocal()
 
-            m_impulse.x += impulse1.x
-            m_impulse.y += impulse1.y
+            impulse.x += impulse1.x
+            impulse.y += impulse1.y
 
             vA.x -= mA * P.x
             vA.y -= mA * P.y
-            wA -= iA * Vec2.cross(m_rA, P)
+            wA -= iA * Vec2.cross(rA, P)
 
             vB.x += mB * P.x
             vB.y += mB * P.y
-            wB += iB * Vec2.cross(m_rB, P)
+            wB += iB * Vec2.cross(rB, P)
         } else {
-            Vec2.crossToOutUnsafe(wA, m_rA, temp)
-            Vec2.crossToOutUnsafe(wB, m_rB, Cdot1)
+            Vec2.crossToOutUnsafe(wA, rA, temp)
+            Vec2.crossToOutUnsafe(wB, rB, Cdot1)
             Cdot1.addLocal(vB).subLocal(vA).subLocal(temp)
             val Cdot2 = wB - wA
 
@@ -274,36 +253,34 @@ class WeldJoint(argWorld: IWorldPool, def: WeldJointDef) : Joint(argWorld, def) 
             Cdot.set(Cdot1.x, Cdot1.y, Cdot2)
 
             val impulse = pool.popVec3()
-            Mat33.mulToOutUnsafe(m_mass, Cdot, impulse)
+            Mat33.mulToOutUnsafe(mass, Cdot, impulse)
             impulse.negateLocal()
-            m_impulse.addLocal(impulse)
+            this.impulse.addLocal(impulse)
 
             P.set(impulse.x, impulse.y)
 
             vA.x -= mA * P.x
             vA.y -= mA * P.y
-            wA -= iA * (Vec2.cross(m_rA, P) + impulse.z)
+            wA -= iA * (Vec2.cross(rA, P) + impulse.z)
 
             vB.x += mB * P.x
             vB.y += mB * P.y
-            wB += iB * (Vec2.cross(m_rB, P) + impulse.z)
+            wB += iB * (Vec2.cross(rB, P) + impulse.z)
 
             pool.pushVec3(2)
         }
 
-        //    data.velocities[m_indexA].v.set(vA);
-        data.velocities!![m_indexA].w = wA
-        //    data.velocities[m_indexB].v.set(vB);
-        data.velocities!![m_indexB].w = wB
+        data.velocities!![indexA].w = wA
+        data.velocities!![indexB].w = wB
 
         pool.pushVec2(3)
     }
 
     override fun solvePositionConstraints(data: SolverData): Boolean {
-        val cA = data.positions!![m_indexA].c
-        var aA = data.positions!![m_indexA].a
-        val cB = data.positions!![m_indexB].c
-        var aB = data.positions!![m_indexB].a
+        val cA = data.positions!![indexA].c
+        var aA = data.positions!![indexA].a
+        val cB = data.positions!![indexB].c
+        var aB = data.positions!![indexB].a
         val qA = pool.popRot()
         val qB = pool.popRot()
         val temp = pool.popVec2()
@@ -313,13 +290,13 @@ class WeldJoint(argWorld: IWorldPool, def: WeldJointDef) : Joint(argWorld, def) 
         qA.setRadians(aA)
         qB.setRadians(aB)
 
-        val mA = m_invMassA
-        val mB = m_invMassB
-        val iA = m_invIA
-        val iB = m_invIB
+        val mA = invMassA
+        val mB = invMassB
+        val iA = invIA
+        val iB = invIB
 
-        Rot.mulToOutUnsafe(qA, temp.set(localAnchorA).subLocal(m_localCenterA), rA)
-        Rot.mulToOutUnsafe(qB, temp.set(localAnchorB).subLocal(m_localCenterB), rB)
+        Rot.mulToOutUnsafe(qA, temp.set(localAnchorA).subLocal(localCenterA), rA)
+        Rot.mulToOutUnsafe(qB, temp.set(localAnchorB).subLocal(localCenterB), rB)
         val positionError: Float
         val angularError: Float
 
@@ -377,10 +354,8 @@ class WeldJoint(argWorld: IWorldPool, def: WeldJointDef) : Joint(argWorld, def) 
             pool.pushVec3(2)
         }
 
-        //    data.positions[m_indexA].c.set(cA);
-        data.positions!![m_indexA].a = aA
-        //    data.positions[m_indexB].c.set(cB);
-        data.positions!![m_indexB].a = aB
+        data.positions!![indexA].a = aA
+        data.positions!![indexB].a = aB
 
         pool.pushVec2(5)
         pool.pushRot(2)

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/WeldJointDef.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/WeldJointDef.kt
@@ -21,6 +21,9 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+/**
+ * Created at 3:38:52 AM Jan 15, 2011
+ */
 package org.jbox2d.dynamics.joints
 
 import com.soywiz.korma.geom.*
@@ -28,23 +31,18 @@ import org.jbox2d.common.*
 import org.jbox2d.dynamics.Body
 
 /**
- * Created at 3:38:52 AM Jan 15, 2011
- */
-
-/**
  * @author Daniel Murphy
  */
 class WeldJointDef : JointDef(JointType.WELD) {
+
     /**
      * The local anchor point relative to body1's origin.
      */
-
     val localAnchorA: Vec2 = Vec2()
 
     /**
      * The local anchor point relative to body2's origin.
      */
-
     val localAnchorB: Vec2 = Vec2()
 
     /**
@@ -69,21 +67,15 @@ class WeldJointDef : JointDef(JointType.WELD) {
     /**
      * The mass-spring-damper frequency in Hertz. Rotation only. Disable softness with a value of 0.
      */
-
     var frequencyHz: Float = 0f
 
     /**
      * The damping ratio. 0 = no damping, 1 = critical damping.
      */
-
     var dampingRatio: Float = 0f
 
     /**
      * Initialize the bodies, anchors, and reference angle using a world anchor point.
-     *
-     * @param bA
-     * @param bB
-     * @param anchor
      */
     fun initialize(bA: Body, bB: Body, anchor: Vec2) {
         bodyA = bA

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/WheelJoint.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/WheelJoint.kt
@@ -30,22 +30,6 @@ import org.jbox2d.common.Vec2
 import org.jbox2d.dynamics.SolverData
 import org.jbox2d.pooling.IWorldPool
 
-//Linear constraint (point-to-line)
-//d = pB - pA = xB + rB - xA - rA
-//C = dot(ay, d)
-//Cdot = dot(d, cross(wA, ay)) + dot(ay, vB + cross(wB, rB) - vA - cross(wA, rA))
-//   = -dot(ay, vA) - dot(cross(d + rA, ay), wA) + dot(ay, vB) + dot(cross(rB, ay), vB)
-//J = [-ay, -cross(d + rA, ay), ay, cross(rB, ay)]
-
-//Spring linear constraint
-//C = dot(ax, d)
-//Cdot = = -dot(ax, vA) - dot(cross(d + rA, ax), wA) + dot(ax, vB) + dot(cross(rB, ax), vB)
-//J = [-ax -cross(d+rA, ax) ax cross(rB, ax)]
-
-//Motor rotational constraint
-//Cdot = wB - wA
-//J = [0 0 -1 0 0 1]
-
 /**
  * A wheel joint. This joint provides two degrees of freedom: translation along an axis fixed in
  * bodyA and rotation in the plane. You can use a joint limit to restrict the range of motion and a
@@ -56,57 +40,58 @@ import org.jbox2d.pooling.IWorldPool
  */
 class WheelJoint(argPool: IWorldPool, def: WheelJointDef) : Joint(argPool, def) {
 
-    var springFrequencyHz: Float = 0.toFloat()
-
-    var springDampingRatio: Float = 0.toFloat()
+    var springFrequencyHz: Float = def.frequencyHz
+    var springDampingRatio: Float = def.dampingRatio
 
     // Solver shared
+    val localAnchorA = Vec2().set(def.localAnchorA)
+    val localAnchorB = Vec2().set(def.localAnchorB)
 
-    val localAnchorA = Vec2()
-
-    val localAnchorB = Vec2()
     /** For serialization  */
+    val localAxisA = Vec2().set(def.localAxisA)
+    private val localYAxisA = Vec2()
 
-    val localAxisA = Vec2()
-    private val m_localYAxisA = Vec2()
+    init {
+        Vec2.crossToOutUnsafe(1.0f, localAxisA, localYAxisA)
+    }
 
-    private var m_impulse: Float = 0.toFloat()
-    private var m_motorImpulse: Float = 0.toFloat()
-    private var m_springImpulse: Float = 0.toFloat()
+    private var impulse: Float = 0f
+    private var motorImpulse: Float = 0f
+    private var springImpulse: Float = 0f
 
-    private var m_maxMotorTorque: Float = 0.toFloat()
-    private var m_motorSpeed: Float = 0.toFloat()
-    var isMotorEnabled: Boolean = false
+    private var _maxMotorTorque: Float = def.maxMotorTorque
+    private var _motorSpeed: Float = def.motorSpeed
+    var isMotorEnabled: Boolean = def.enableMotor
         private set
 
     // Solver temp
-    private var m_indexA: Int = 0
-    private var m_indexB: Int = 0
-    private val m_localCenterA = Vec2()
-    private val m_localCenterB = Vec2()
-    private var m_invMassA: Float = 0.toFloat()
-    private var m_invMassB: Float = 0.toFloat()
-    private var m_invIA: Float = 0.toFloat()
-    private var m_invIB: Float = 0.toFloat()
+    private var indexA: Int = 0
+    private var indexB: Int = 0
+    private val localCenterA = Vec2()
+    private val localCenterB = Vec2()
+    private var invMassA: Float = 0f
+    private var invMassB: Float = 0f
+    private var invIA: Float = 0f
+    private var invIB: Float = 0f
 
-    private val m_ax = Vec2()
-    private val m_ay = Vec2()
-    private var m_sAx: Float = 0.toFloat()
-    private var m_sBx: Float = 0.toFloat()
-    private var m_sAy: Float = 0.toFloat()
-    private var m_sBy: Float = 0.toFloat()
+    private val ax = Vec2()
+    private val ay = Vec2()
+    private var sAx: Float = 0f
+    private var sBx: Float = 0f
+    private var sAy: Float = 0f
+    private var sBy: Float = 0f
 
-    private var m_mass: Float = 0.toFloat()
-    private var m_motorMass: Float = 0.toFloat()
-    private var m_springMass: Float = 0.toFloat()
+    private var mass: Float = 0f
+    private var motorMass: Float = 0f
+    private var springMass: Float = 0f
 
-    private var m_bias: Float = 0.toFloat()
-    private var m_gamma: Float = 0.toFloat()
+    private var bias: Float = 0f
+    private var gamma: Float = 0f
 
     val jointTranslation: Float
         get() {
-            val b1 = m_bodyA
-            val b2 = m_bodyB
+            val b1 = bodyA
+            val b2 = bodyB
 
             val p1 = pool.popVec2()
             val p2 = pool.popVec2()
@@ -122,22 +107,22 @@ class WheelJoint(argPool: IWorldPool, def: WheelJointDef) : Joint(argPool, def) 
         }
 
     val jointSpeed: Float
-        get() = m_bodyA!!.m_angularVelocity - m_bodyB!!.m_angularVelocity
+        get() = bodyA!!._angularVelocity - bodyB!!._angularVelocity
 
     var motorSpeed: Float
-        get() = m_motorSpeed
+        get() = _motorSpeed
         set(speed) {
-            m_bodyA!!.isAwake = true
-            m_bodyB!!.isAwake = true
-            m_motorSpeed = speed
+            bodyA!!.isAwake = true
+            bodyB!!.isAwake = true
+            _motorSpeed = speed
         }
 
     var maxMotorTorque: Float
-        get() = m_maxMotorTorque
+        get() = _maxMotorTorque
         set(torque) {
-            m_bodyA!!.isAwake = true
-            m_bodyB!!.isAwake = true
-            m_maxMotorTorque = torque
+            bodyA!!.isAwake = true
+            bodyB!!.isAwake = true
+            _maxMotorTorque = torque
         }
 
     // pooling
@@ -145,77 +130,59 @@ class WheelJoint(argPool: IWorldPool, def: WheelJointDef) : Joint(argPool, def) 
     private val rB = Vec2()
     private val d = Vec2()
 
-    init {
-        localAnchorA.set(def.localAnchorA)
-        localAnchorB.set(def.localAnchorB)
-        localAxisA.set(def.localAxisA)
-        Vec2.crossToOutUnsafe(1.0f, localAxisA, m_localYAxisA)
-
-
-        m_motorMass = 0.0f
-        m_motorImpulse = 0.0f
-
-        m_maxMotorTorque = def.maxMotorTorque
-        m_motorSpeed = def.motorSpeed
-        isMotorEnabled = def.enableMotor
-
-        springFrequencyHz = def.frequencyHz
-        springDampingRatio = def.dampingRatio
+    override fun getAnchorA(out: Vec2) {
+        bodyA!!.getWorldPointToOut(localAnchorA, out)
     }
 
-    override fun getAnchorA(argOut: Vec2) {
-        m_bodyA!!.getWorldPointToOut(localAnchorA, argOut)
+    override fun getAnchorB(out: Vec2) {
+        bodyB!!.getWorldPointToOut(localAnchorB, out)
     }
 
-    override fun getAnchorB(argOut: Vec2) {
-        m_bodyB!!.getWorldPointToOut(localAnchorB, argOut)
-    }
-
-    override fun getReactionForce(inv_dt: Float, argOut: Vec2) {
+    override fun getReactionForce(invDt: Float, out: Vec2) {
         val temp = pool.popVec2()
-        temp.set(m_ay).mulLocal(m_impulse)
-        argOut.set(m_ax).mulLocal(m_springImpulse).addLocal(temp).mulLocal(inv_dt)
+        temp.set(ay).mulLocal(impulse)
+        out.set(ax).mulLocal(springImpulse).addLocal(temp).mulLocal(invDt)
         pool.pushVec2(1)
     }
 
-    override fun getReactionTorque(inv_dt: Float): Float {
-        return inv_dt * m_motorImpulse
+    override fun getReactionTorque(invDt: Float): Float {
+        return invDt * motorImpulse
     }
 
     fun enableMotor(flag: Boolean) {
-        m_bodyA!!.isAwake = true
-        m_bodyB!!.isAwake = true
+        bodyA!!.isAwake = true
+        bodyB!!.isAwake = true
         isMotorEnabled = flag
     }
 
-    fun getMotorTorque(inv_dt: Float): Float {
-        return m_motorImpulse * inv_dt
+    fun getMotorTorque(invDt: Float): Float {
+        return motorImpulse * invDt
     }
 
     override fun initVelocityConstraints(data: SolverData) {
-        m_indexA = m_bodyA!!.m_islandIndex
-        m_indexB = m_bodyB!!.m_islandIndex
-        m_localCenterA.set(m_bodyA!!.m_sweep.localCenter)
-        m_localCenterB.set(m_bodyB!!.m_sweep.localCenter)
-        m_invMassA = m_bodyA!!.m_invMass
-        m_invMassB = m_bodyB!!.m_invMass
-        m_invIA = m_bodyA!!.m_invI
-        m_invIB = m_bodyB!!.m_invI
+        indexA = bodyA!!.islandIndex
+        indexB = bodyB!!.islandIndex
+        localCenterA.set(bodyA!!.sweep.localCenter)
+        localCenterB.set(bodyB!!.sweep.localCenter)
+        invMassA = bodyA!!.invMass
+        invMassB = bodyB!!.invMass
+        invIA = bodyA!!.invI
+        invIB = bodyB!!.invI
 
-        val mA = m_invMassA
-        val mB = m_invMassB
-        val iA = m_invIA
-        val iB = m_invIB
+        val mA = invMassA
+        val mB = invMassB
+        val iA = invIA
+        val iB = invIB
 
-        val cA = data.positions!![m_indexA].c
-        val aA = data.positions!![m_indexA].a
-        val vA = data.velocities!![m_indexA].v
-        var wA = data.velocities!![m_indexA].w
+        val cA = data.positions!![indexA].c
+        val aA = data.positions!![indexA].a
+        val vA = data.velocities!![indexA].v
+        var wA = data.velocities!![indexA].w
 
-        val cB = data.positions!![m_indexB].c
-        val aB = data.positions!![m_indexB].a
-        val vB = data.velocities!![m_indexB].v
-        var wB = data.velocities!![m_indexB].w
+        val cB = data.positions!![indexB].c
+        val aB = data.positions!![indexB].a
+        val vB = data.velocities!![indexB].v
+        var wB = data.velocities!![indexB].w
 
         val qA = pool.popRot()
         val qB = pool.popRot()
@@ -225,135 +192,133 @@ class WheelJoint(argPool: IWorldPool, def: WheelJointDef) : Joint(argPool, def) 
         qB.setRadians(aB)
 
         // Compute the effective masses.
-        Rot.mulToOutUnsafe(qA, temp.set(localAnchorA).subLocal(m_localCenterA), rA)
-        Rot.mulToOutUnsafe(qB, temp.set(localAnchorB).subLocal(m_localCenterB), rB)
+        Rot.mulToOutUnsafe(qA, temp.set(localAnchorA).subLocal(localCenterA), rA)
+        Rot.mulToOutUnsafe(qB, temp.set(localAnchorB).subLocal(localCenterB), rB)
         d.set(cB).addLocal(rB).subLocal(cA).subLocal(rA)
 
         // Point to line constraint
         run {
-            Rot.mulToOut(qA, m_localYAxisA, m_ay)
-            m_sAy = Vec2.cross(temp.set(d).addLocal(rA), m_ay)
-            m_sBy = Vec2.cross(rB, m_ay)
+            Rot.mulToOut(qA, localYAxisA, ay)
+            sAy = Vec2.cross(temp.set(d).addLocal(rA), ay)
+            sBy = Vec2.cross(rB, ay)
 
-            m_mass = mA + mB + iA * m_sAy * m_sAy + iB * m_sBy * m_sBy
+            mass = mA + mB + iA * sAy * sAy + iB * sBy * sBy
 
-            if (m_mass > 0.0f) {
-                m_mass = 1.0f / m_mass
+            if (mass > 0.0f) {
+                mass = 1.0f / mass
             }
         }
 
         // Spring constraint
-        m_springMass = 0.0f
-        m_bias = 0.0f
-        m_gamma = 0.0f
+        springMass = 0.0f
+        bias = 0.0f
+        gamma = 0.0f
         if (springFrequencyHz > 0.0f) {
-            Rot.mulToOut(qA, localAxisA, m_ax)
-            m_sAx = Vec2.cross(temp.set(d).addLocal(rA), m_ax)
-            m_sBx = Vec2.cross(rB, m_ax)
+            Rot.mulToOut(qA, localAxisA, ax)
+            sAx = Vec2.cross(temp.set(d).addLocal(rA), ax)
+            sBx = Vec2.cross(rB, ax)
 
-            val invMass = mA + mB + iA * m_sAx * m_sAx + iB * m_sBx * m_sBx
+            val invMass = mA + mB + iA * sAx * sAx + iB * sBx * sBx
 
             if (invMass > 0.0f) {
-                m_springMass = 1.0f / invMass
+                springMass = 1.0f / invMass
 
-                val C = Vec2.dot(d, m_ax)
+                val C = Vec2.dot(d, ax)
 
                 // Frequency
                 val omega = 2.0f * MathUtils.PI * springFrequencyHz
 
                 // Damping coefficient
-                val d = 2.0f * m_springMass * springDampingRatio * omega
+                val d = 2.0f * springMass * springDampingRatio * omega
 
                 // Spring stiffness
-                val k = m_springMass * omega * omega
+                val k = springMass * omega * omega
 
                 // magic formulas
                 val h = data.step!!.dt
-                m_gamma = h * (d + h * k)
-                if (m_gamma > 0.0f) {
-                    m_gamma = 1.0f / m_gamma
+                gamma = h * (d + h * k)
+                if (gamma > 0.0f) {
+                    gamma = 1.0f / gamma
                 }
 
-                m_bias = C * h * k * m_gamma
+                bias = C * h * k * gamma
 
-                m_springMass = invMass + m_gamma
-                if (m_springMass > 0.0f) {
-                    m_springMass = 1.0f / m_springMass
+                springMass = invMass + gamma
+                if (springMass > 0.0f) {
+                    springMass = 1.0f / springMass
                 }
             }
         } else {
-            m_springImpulse = 0.0f
+            springImpulse = 0.0f
         }
 
         // Rotational motor
         if (isMotorEnabled) {
-            m_motorMass = iA + iB
-            if (m_motorMass > 0.0f) {
-                m_motorMass = 1.0f / m_motorMass
+            motorMass = iA + iB
+            if (motorMass > 0.0f) {
+                motorMass = 1.0f / motorMass
             }
         } else {
-            m_motorMass = 0.0f
-            m_motorImpulse = 0.0f
+            motorMass = 0.0f
+            motorImpulse = 0.0f
         }
 
         if (data.step!!.warmStarting) {
             val P = pool.popVec2()
             // Account for variable time step.
-            m_impulse *= data.step!!.dtRatio
-            m_springImpulse *= data.step!!.dtRatio
-            m_motorImpulse *= data.step!!.dtRatio
+            impulse *= data.step!!.dtRatio
+            springImpulse *= data.step!!.dtRatio
+            motorImpulse *= data.step!!.dtRatio
 
-            P.x = m_impulse * m_ay.x + m_springImpulse * m_ax.x
-            P.y = m_impulse * m_ay.y + m_springImpulse * m_ax.y
-            val LA = m_impulse * m_sAy + m_springImpulse * m_sAx + m_motorImpulse
-            val LB = m_impulse * m_sBy + m_springImpulse * m_sBx + m_motorImpulse
+            P.x = impulse * ay.x + springImpulse * ax.x
+            P.y = impulse * ay.y + springImpulse * ax.y
+            val LA = impulse * sAy + springImpulse * sAx + motorImpulse
+            val LB = impulse * sBy + springImpulse * sBx + motorImpulse
 
-            vA.x -= m_invMassA * P.x
-            vA.y -= m_invMassA * P.y
-            wA -= m_invIA * LA
+            vA.x -= invMassA * P.x
+            vA.y -= invMassA * P.y
+            wA -= invIA * LA
 
-            vB.x += m_invMassB * P.x
-            vB.y += m_invMassB * P.y
-            wB += m_invIB * LB
+            vB.x += invMassB * P.x
+            vB.y += invMassB * P.y
+            wB += invIB * LB
             pool.pushVec2(1)
         } else {
-            m_impulse = 0.0f
-            m_springImpulse = 0.0f
-            m_motorImpulse = 0.0f
+            impulse = 0.0f
+            springImpulse = 0.0f
+            motorImpulse = 0.0f
         }
         pool.pushRot(2)
         pool.pushVec2(1)
 
-        // data.velocities[m_indexA].v = vA;
-        data.velocities!![m_indexA].w = wA
-        // data.velocities[m_indexB].v = vB;
-        data.velocities!![m_indexB].w = wB
+        data.velocities!![indexA].w = wA
+        data.velocities!![indexB].w = wB
     }
 
     override fun solveVelocityConstraints(data: SolverData) {
-        val mA = m_invMassA
-        val mB = m_invMassB
-        val iA = m_invIA
-        val iB = m_invIB
+        val mA = invMassA
+        val mB = invMassB
+        val iA = invIA
+        val iB = invIB
 
-        val vA = data.velocities!![m_indexA].v
-        var wA = data.velocities!![m_indexA].w
-        val vB = data.velocities!![m_indexB].v
-        var wB = data.velocities!![m_indexB].w
+        val vA = data.velocities!![indexA].v
+        var wA = data.velocities!![indexA].w
+        val vB = data.velocities!![indexB].v
+        var wB = data.velocities!![indexB].w
 
         val temp = pool.popVec2()
         val P = pool.popVec2()
 
         // Solve spring constraint
         run {
-            val Cdot = Vec2.dot(m_ax, temp.set(vB).subLocal(vA)) + m_sBx * wB - m_sAx * wA
-            val impulse = -m_springMass * (Cdot + m_bias + m_gamma * m_springImpulse)
-            m_springImpulse += impulse
+            val Cdot = Vec2.dot(ax, temp.set(vB).subLocal(vA)) + sBx * wB - sAx * wA
+            val impulse = -springMass * (Cdot + bias + gamma * springImpulse)
+            springImpulse += impulse
 
-            P.x = impulse * m_ax.x
-            P.y = impulse * m_ax.y
-            val LA = impulse * m_sAx
-            val LB = impulse * m_sBx
+            P.x = impulse * ax.x
+            P.y = impulse * ax.y
+            val LA = impulse * sAx
+            val LB = impulse * sBx
 
             vA.x -= mA * P.x
             vA.y -= mA * P.y
@@ -366,13 +331,13 @@ class WheelJoint(argPool: IWorldPool, def: WheelJointDef) : Joint(argPool, def) 
 
         // Solve rotational motor constraint
         run {
-            val Cdot = wB - wA - m_motorSpeed
-            var impulse = -m_motorMass * Cdot
+            val Cdot = wB - wA - _motorSpeed
+            var impulse = -motorMass * Cdot
 
-            val oldImpulse = m_motorImpulse
-            val maxImpulse = data.step!!.dt * m_maxMotorTorque
-            m_motorImpulse = MathUtils.clamp(m_motorImpulse + impulse, -maxImpulse, maxImpulse)
-            impulse = m_motorImpulse - oldImpulse
+            val oldImpulse = motorImpulse
+            val maxImpulse = data.step!!.dt * _maxMotorTorque
+            motorImpulse = MathUtils.clamp(motorImpulse + impulse, -maxImpulse, maxImpulse)
+            impulse = motorImpulse - oldImpulse
 
             wA -= iA * impulse
             wB += iB * impulse
@@ -380,14 +345,14 @@ class WheelJoint(argPool: IWorldPool, def: WheelJointDef) : Joint(argPool, def) 
 
         // Solve point to line constraint
         run {
-            val Cdot = Vec2.dot(m_ay, temp.set(vB).subLocal(vA)) + m_sBy * wB - m_sAy * wA
-            val impulse = -m_mass * Cdot
-            m_impulse += impulse
+            val Cdot = Vec2.dot(ay, temp.set(vB).subLocal(vA)) + sBy * wB - sAy * wA
+            val impulse = -mass * Cdot
+            this.impulse += impulse
 
-            P.x = impulse * m_ay.x
-            P.y = impulse * m_ay.y
-            val LA = impulse * m_sAy
-            val LB = impulse * m_sBy
+            P.x = impulse * ay.x
+            P.y = impulse * ay.y
+            val LA = impulse * sAy
+            val LB = impulse * sBy
 
             vA.x -= mA * P.x
             vA.y -= mA * P.y
@@ -399,17 +364,15 @@ class WheelJoint(argPool: IWorldPool, def: WheelJointDef) : Joint(argPool, def) 
         }
         pool.pushVec2(2)
 
-        // data.velocities[m_indexA].v = vA;
-        data.velocities!![m_indexA].w = wA
-        // data.velocities[m_indexB].v = vB;
-        data.velocities!![m_indexB].w = wB
+        data.velocities!![indexA].w = wA
+        data.velocities!![indexB].w = wB
     }
 
     override fun solvePositionConstraints(data: SolverData): Boolean {
-        val cA = data.positions!![m_indexA].c
-        var aA = data.positions!![m_indexA].a
-        val cB = data.positions!![m_indexB].c
-        var aB = data.positions!![m_indexB].a
+        val cA = data.positions!![indexA].c
+        var aA = data.positions!![indexA].a
+        val cB = data.positions!![indexB].c
+        var aB = data.positions!![indexB].a
 
         val qA = pool.popRot()
         val qB = pool.popRot()
@@ -418,26 +381,21 @@ class WheelJoint(argPool: IWorldPool, def: WheelJointDef) : Joint(argPool, def) 
         qA.setRadians(aA)
         qB.setRadians(aB)
 
-        Rot.mulToOut(qA, temp.set(localAnchorA).subLocal(m_localCenterA), rA)
-        Rot.mulToOut(qB, temp.set(localAnchorB).subLocal(m_localCenterB), rB)
+        Rot.mulToOut(qA, temp.set(localAnchorA).subLocal(localCenterA), rA)
+        Rot.mulToOut(qB, temp.set(localAnchorB).subLocal(localCenterB), rB)
         d.set(cB).subLocal(cA).addLocal(rB).subLocal(rA)
 
         val ay = pool.popVec2()
-        Rot.mulToOut(qA, m_localYAxisA, ay)
+        Rot.mulToOut(qA, localYAxisA, ay)
 
         val sAy = Vec2.cross(temp.set(d).addLocal(rA), ay)
         val sBy = Vec2.cross(rB, ay)
 
         val C = Vec2.dot(d, ay)
 
-        val k = m_invMassA + m_invMassB + m_invIA * m_sAy * m_sAy + m_invIB * m_sBy * m_sBy
+        val k = invMassA + invMassB + invIA * this.sAy * this.sAy + invIB * this.sBy * this.sBy
 
-        val impulse: Float
-        if (k != 0.0f) {
-            impulse = -C / k
-        } else {
-            impulse = 0.0f
-        }
+        val impulse = if (k != 0.0f) -C / k else 0.0f
 
         val P = pool.popVec2()
         P.x = impulse * ay.x
@@ -445,19 +403,17 @@ class WheelJoint(argPool: IWorldPool, def: WheelJointDef) : Joint(argPool, def) 
         val LA = impulse * sAy
         val LB = impulse * sBy
 
-        cA.x -= m_invMassA * P.x
-        cA.y -= m_invMassA * P.y
-        aA -= m_invIA * LA
-        cB.x += m_invMassB * P.x
-        cB.y += m_invMassB * P.y
-        aB += m_invIB * LB
+        cA.x -= invMassA * P.x
+        cA.y -= invMassA * P.y
+        aA -= invIA * LA
+        cB.x += invMassB * P.x
+        cB.y += invMassB * P.y
+        aB += invIB * LB
 
         pool.pushVec2(3)
         pool.pushRot(2)
-        // data.positions[m_indexA].c = cA;
-        data.positions!![m_indexA].a = aA
-        // data.positions[m_indexB].c = cB;
-        data.positions!![m_indexB].a = aB
+        data.positions!![indexA].a = aA
+        data.positions!![indexB].a = aB
 
         return MathUtils.abs(C) <= Settings.linearSlop
     }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/WheelJointDef.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/dynamics/joints/WheelJointDef.kt
@@ -43,50 +43,42 @@ class WheelJointDef : JointDef(JointType.WHEEL) {
     /**
      * The local anchor point relative to body1's origin.
      */
-
     val localAnchorA = Vec2()
 
     /**
      * The local anchor point relative to body2's origin.
      */
-
     val localAnchorB = Vec2()
 
     /**
      * The local translation axis in body1.
      */
-
     val localAxisA = Vec2(1f, 0f)
 
     /**
      * Enable/disable the joint motor.
      */
-
     var enableMotor: Boolean = false
 
     /**
      * The maximum motor torque, usually in N-m.
      */
-
     var maxMotorTorque: Float = 0f
 
     /**
      * The desired motor speed in radians per second.
      */
-
     var motorSpeed: Float = 0f
 
     /**
      * Suspension frequency, zero indicates no suspension
      */
-
     var frequencyHz: Float = 0f
 
     /**
      * Suspension damping ratio, one indicates critical damping
      */
-
-    var dampingRatio: Float = 0.toFloat()
+    var dampingRatio: Float = 0f
 
     fun initialize(b1: Body, b2: Body, anchor: Vec2, axis: Vec2) {
         bodyA = b1

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/particle/ParticleBodyContact.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/particle/ParticleBodyContact.kt
@@ -4,19 +4,19 @@ import org.jbox2d.common.Vec2
 import org.jbox2d.dynamics.Body
 
 class ParticleBodyContact {
+
     /** Index of the particle making contact.  */
-
     var index: Int = 0
+
     /** The body making contact.  */
-
     var body: Body? = null
+
     /** Weight of the contact. A value between 0.0f and 1.0f.  */
+    internal var weight: Float = 0f
 
-    internal var weight: Float = 0.toFloat()
     /** The normalized direction from the particle to the body.  */
-
     val normal = Vec2()
-    /** The effective mass used in calculating force.  */
 
-    internal var mass: Float = 0.toFloat()
+    /** The effective mass used in calculating force.  */
+    internal var mass: Float = 0f
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/particle/ParticleColor.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/particle/ParticleColor.kt
@@ -10,11 +10,8 @@ import org.jbox2d.common.Color3f
 class ParticleColor {
 
     var r: Byte = 0
-
     var g: Byte = 0
-
     var b: Byte = 0
-
     var a: Byte = 0
 
     val isZero: Boolean

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/particle/ParticleContact.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/particle/ParticleContact.kt
@@ -3,18 +3,17 @@ package org.jbox2d.particle
 import org.jbox2d.common.Vec2
 
 class ParticleContact {
+
     /** Indices of the respective particles making contact.  */
-
     var indexA: Int = 0
-
     var indexB: Int = 0
+
     /** The logical sum of the particle behaviors that have been set.  */
-
     var flags: Int = 0
+
     /** Weight of the contact. A value between 0.0f and 1.0f.  */
+    var weight: Float = 0f
 
-    var weight: Float = 0.toFloat()
     /** The normalized direction from A to B.  */
-
     val normal = Vec2()
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/particle/ParticleDef.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/particle/ParticleDef.kt
@@ -4,27 +4,23 @@ import org.jbox2d.common.*
 import org.jbox2d.userdata.*
 
 class ParticleDef : Box2dTypedUserData by Box2dTypedUserData.Mixin() {
+
     /**
      * Specifies the type of particle. A particle may be more than one type. Multiple types are
      * chained by logical sums, for example: pd.flags = ParticleType.b2_elasticParticle |
      * ParticleType.b2_viscousParticle.
      */
-
     internal var flags: Int = 0
 
     /** The world position of the particle.  */
-
     val position = Vec2()
 
     /** The linear velocity of the particle in world co-ordinates.  */
-
     val velocity = Vec2()
 
     /** The color of the particle.  */
-
     var color: ParticleColor? = null
 
     /** Use this to store application-specific body data.  */
-
     var userData: Any? = null
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/particle/ParticleGroup.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/particle/ParticleGroup.kt
@@ -6,143 +6,112 @@ import org.jbox2d.common.Vec2
 
 class ParticleGroup {
 
-    internal var m_system: ParticleSystem? = null
+    internal var system: ParticleSystem? = null
 
-    var m_firstIndex: Int = 0
+    var firstIndex: Int = 0
+    internal var lastIndex: Int = 0
 
-    internal var m_lastIndex: Int = 0
+    var groupFlags: Int = 0
+    
+    internal var strength: Float = 1.0f
 
-    var m_groupFlags: Int = 0
+    internal var prev: ParticleGroup? = null
+    var next: ParticleGroup? = null
 
-    internal var m_strength: Float = 0.toFloat()
+    internal var timestamp: Int = -1
+    internal var _mass: Float = 0f
+    internal var _inertia: Float = 0f
 
-    internal var m_prev: ParticleGroup? = null
+    internal val _center = Vec2()
 
-    var m_next: ParticleGroup? = null
+    internal val _linearVelocity = Vec2()
+    internal var _angularVelocity: Float = 0f
 
-    fun getNext() = m_next
+    val transform = Transform().apply { setIdentity() }
 
+    internal var destroyAutomatically: Boolean = true
+    internal var toBeDestroyed: Boolean = false
+    internal var toBeSplit: Boolean = false
 
-    internal var m_timestamp: Int = 0
-
-    internal var m_mass: Float = 0.toFloat()
-
-    internal var m_inertia: Float = 0.toFloat()
-
-    internal val m_center = Vec2()
-
-    internal val m_linearVelocity = Vec2()
-
-    internal var m_angularVelocity: Float = 0.toFloat()
-
-    val m_transform = Transform()
-
-
-    internal var m_destroyAutomatically: Boolean = false
-
-    internal var m_toBeDestroyed: Boolean = false
-
-    internal var m_toBeSplit: Boolean = false
-
-
-    var m_userData: Any? = null
+    var userData: Any? = null
 
     val particleCount: Int
-        get() = m_lastIndex - m_firstIndex
+        get() = lastIndex - firstIndex
 
     val mass: Float
         get() {
             updateStatistics()
-            return m_mass
+            return _mass
         }
 
     val inertia: Float
         get() {
             updateStatistics()
-            return m_inertia
+            return _inertia
         }
 
     val center: Vec2
         get() {
             updateStatistics()
-            return m_center
+            return _center
         }
 
     val linearVelocity: Vec2
         get() {
             updateStatistics()
-            return m_linearVelocity
+            return _linearVelocity
         }
 
     val angularVelocity: Float
         get() {
             updateStatistics()
-            return m_angularVelocity
+            return _angularVelocity
         }
 
     val position: Vec2
-        get() = m_transform.p
+        get() = transform.p
 
-    val angleRadians: Float get() = m_transform.q.angleRadians
-    val angleDegrees: Float get() = m_transform.q.angleDegrees
-    val angle: Angle get() = m_transform.q.angle
-
-    init {
-        // m_system = null;
-        m_firstIndex = 0
-        m_lastIndex = 0
-        m_groupFlags = 0
-        m_strength = 1.0f
-
-        m_timestamp = -1
-        m_mass = 0f
-        m_inertia = 0f
-        m_angularVelocity = 0f
-        m_transform.setIdentity()
-
-        m_destroyAutomatically = true
-        m_toBeDestroyed = false
-        m_toBeSplit = false
-    }
-
+    val angleRadians: Float get() = transform.q.angleRadians
+    val angleDegrees: Float get() = transform.q.angleDegrees
+    val angle: Angle get() = transform.q.angle
 
     fun updateStatistics() {
-        if (m_timestamp != m_system!!.m_timestamp) {
-            val m = m_system!!.particleMass
-            m_mass = 0f
-            m_center.setZero()
-            m_linearVelocity.setZero()
-            for (i in m_firstIndex until m_lastIndex) {
-                m_mass += m
-                val pos = m_system!!.m_positionBuffer!!.data!![i]
-                m_center.x += m * pos.x
-                m_center.y += m * pos.y
-                val vel = m_system!!.m_velocityBuffer.data!![i]
-                m_linearVelocity.x += m * vel.x
-                m_linearVelocity.y += m * vel.y
+        if (timestamp != system!!.timestamp) {
+            val m = system!!.particleMass
+            _mass = 0f
+            _center.setZero()
+            _linearVelocity.setZero()
+            for (i in firstIndex until lastIndex) {
+                _mass += m
+                val pos = system!!.positionBuffer.data!![i]
+                _center.x += m * pos.x
+                _center.y += m * pos.y
+                val vel = system!!.velocityBuffer.data!![i]
+                _linearVelocity.x += m * vel.x
+                _linearVelocity.y += m * vel.y
             }
-            if (m_mass > 0) {
-                m_center.x *= 1 / m_mass
-                m_center.y *= 1 / m_mass
-                m_linearVelocity.x *= 1 / m_mass
-                m_linearVelocity.y *= 1 / m_mass
+            if (_mass > 0) {
+                _center.x *= 1 / _mass
+                _center.y *= 1 / _mass
+                _linearVelocity.x *= 1 / _mass
+                _linearVelocity.y *= 1 / _mass
             }
-            m_inertia = 0f
-            m_angularVelocity = 0f
-            for (i in m_firstIndex until m_lastIndex) {
-                val pos = m_system!!.m_positionBuffer.data!![i]
-                val vel = m_system!!.m_velocityBuffer.data!![i]
-                val px = pos.x - m_center.x
-                val py = pos.y - m_center.y
-                val vx = vel.x - m_linearVelocity.x
-                val vy = vel.y - m_linearVelocity.y
-                m_inertia += m * (px * px + py * py)
-                m_angularVelocity += m * (px * vy - py * vx)
+            _inertia = 0f
+            _angularVelocity = 0f
+            for (i in firstIndex until lastIndex) {
+                val pos = system!!.positionBuffer.data!![i]
+                val vel = system!!.velocityBuffer.data!![i]
+                val px = pos.x - _center.x
+                val py = pos.y - _center.y
+                val vx = vel.x - _linearVelocity.x
+                val vy = vel.y - _linearVelocity.y
+                _inertia += m * (px * px + py * py)
+                _angularVelocity += m * (px * vy - py * vx)
             }
-            if (m_inertia > 0) {
-                m_angularVelocity *= 1 / m_inertia
+            if (_inertia > 0) {
+                _angularVelocity *= 1 / _inertia
             }
-            m_timestamp = m_system!!.m_timestamp
+            timestamp = system!!.timestamp
         }
     }
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/particle/ParticleGroupDef.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/particle/ParticleGroupDef.kt
@@ -12,18 +12,15 @@ import org.jbox2d.userdata.*
 class ParticleGroupDef : Box2dTypedUserData by Box2dTypedUserData.Mixin() {
 
     /** The particle-behavior flags.  */
-
     var flags: Int = 0
 
     /** The group-construction flags.  */
-
     var groupFlags: Int = 0
 
     /**
      * The world position of the group. Moves the group's shape a distance equal to the value of
      * position.
      */
-
     val position = Vec2()
 
     /**
@@ -49,33 +46,26 @@ class ParticleGroupDef : Box2dTypedUserData by Box2dTypedUserData.Mixin() {
         get() = angleRadians.radians
 
     /** The linear velocity of the group's origin in world co-ordinates.  */
-
     val linearVelocity = Vec2()
 
     /** The angular velocity of the group.  */
-
     var angularVelocity: Float = 0f
 
     /** The color of all particles in the group.  */
-
     var color: ParticleColor? = null
 
     /**
      * The strength of cohesion among the particles in a group with flag b2_elasticParticle or
      * b2_springParticle.
      */
-
     var strength: Float = 1f
 
     /** Shape containing the particle group.  */
-
     var shape: Shape? = null
 
     /** If true, destroy the group automatically after its last particle has been destroyed.  */
-
     var destroyAutomatically: Boolean = true
 
     /** Use this to store application-specific group data.  */
-
     var userData: Any? = null
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/particle/ParticleGroupType.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/particle/ParticleGroupType.kt
@@ -1,10 +1,10 @@
 package org.jbox2d.particle
 
 object ParticleGroupType {
+
     /** resists penetration  */
+    val solidParticleGroup = 1 shl 0
 
-    val b2_solidParticleGroup = 1 shl 0
     /** keeps its shape  */
-
-    val b2_rigidParticleGroup = 1 shl 1
+    val rigidParticleGroup = 1 shl 1
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/particle/ParticleSystem.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/particle/ParticleSystem.kt
@@ -20,68 +20,68 @@ import org.jbox2d.internal.*
 import org.jbox2d.particle.VoronoiDiagram.VoronoiDiagramCallback
 import kotlin.experimental.and
 
-class ParticleSystem(internal var m_world: World) {
+class ParticleSystem(internal var world: World) {
 
-    internal var m_timestamp: Int = 0
-    internal var m_allParticleFlags: Int = 0
-    internal var m_allGroupFlags: Int = 0
-    internal var m_density: Float = 1f
-    internal var m_inverseDensity: Float = 1f
+    internal var timestamp: Int = 0
+    internal var allParticleFlags: Int = 0
+    internal var allGroupFlags: Int = 0
+    internal var density: Float = 1f
+    internal var inverseDensity: Float = 1f
     var particleGravityScale: Float = 1f
-    internal var m_particleDiameter: Float = 1f
-    internal var m_inverseDiameter: Float = 1f
-    internal var m_squaredDiameter: Float = 1f
+    internal var particleDiameter: Float = 1f
+    internal var inverseDiameter: Float = 1f
+    internal var squaredDiameter: Float = 1f
 
     var particleCount: Int = 0
         internal set
-    internal var m_internalAllocatedCapacity: Int = 0
-    internal var m_maxCount: Int = 0
-    internal var m_flagsBuffer: ParticleBufferInt = ParticleBufferInt()
-    internal var m_positionBuffer: ParticleBuffer<Vec2> = ParticleBuffer { Vec2() }
-    internal var m_velocityBuffer: ParticleBuffer<Vec2> = ParticleBuffer { Vec2() }
-    internal var m_accumulationBuffer: FloatArray = FloatArray(0) // temporary values
-    internal var m_accumulation2Buffer: Array<Vec2> = emptyArray() // temporary vector values
-    internal var m_depthBuffer: FloatArray? = null // distance from the surface
+    internal var internalAllocatedCapacity: Int = 0
+    internal var maxCount: Int = 0
+    internal var flagsBuffer: ParticleBufferInt = ParticleBufferInt()
+    internal var positionBuffer: ParticleBuffer<Vec2> = ParticleBuffer { Vec2() }
+    internal var velocityBuffer: ParticleBuffer<Vec2> = ParticleBuffer { Vec2() }
+    internal var accumulationBuffer: FloatArray = FloatArray(0) // temporary values
+    internal var accumulation2Buffer: Array<Vec2> = emptyArray() // temporary vector values
+    internal var depthBuffer: FloatArray? = null // distance from the surface
 
-    var m_colorBuffer: ParticleBuffer<ParticleColor> = ParticleBuffer { ParticleColor() }
+    var colorBuffer: ParticleBuffer<ParticleColor> = ParticleBuffer { ParticleColor() }
     var particleGroupBuffer: Array<ParticleGroup?> = emptyArray()
         internal set
-    internal var m_userDataBuffer: ParticleBuffer<Any> = ParticleBuffer { Any() }
+    internal var userDataBuffer: ParticleBuffer<Any> = ParticleBuffer { Any() }
 
-    internal var m_proxyCount: Int = 0
-    internal var m_proxyCapacity: Int = 0
-    internal var m_proxyBuffer: Array<Proxy> = emptyArray()
+    internal var proxyCount: Int = 0
+    internal var proxyCapacity: Int = 0
+    internal var proxyBuffer: Array<Proxy> = emptyArray()
 
-    var m_contactCount: Int = 0
-    internal var m_contactCapacity: Int = 0
-    var m_contactBuffer: Array<ParticleContact> = emptyArray()
+    var contactCount: Int = 0
+    internal var contactCapacity: Int = 0
+    var contactBuffer: Array<ParticleContact> = emptyArray()
 
-    var m_bodyContactCount: Int = 0
-    internal var m_bodyContactCapacity: Int = 0
-    var m_bodyContactBuffer: Array<ParticleBodyContact> = emptyArray()
+    var bodyContactCount: Int = 0
+    internal var bodyContactCapacity: Int = 0
+    var bodyContactBuffer: Array<ParticleBodyContact> = emptyArray()
 
-    internal var m_pairCount: Int = 0
-    internal var m_pairCapacity: Int = 0
-    internal var m_pairBuffer: Array<Pair> = emptyArray()
+    internal var pairCount: Int = 0
+    internal var pairCapacity: Int = 0
+    internal var pairBuffer: Array<Pair> = emptyArray()
 
-    internal var m_triadCount: Int = 0
-    internal var m_triadCapacity: Int = 0
-    internal var m_triadBuffer: Array<Triad> = emptyArray()
+    internal var triadCount: Int = 0
+    internal var triadCapacity: Int = 0
+    internal var triadBuffer: Array<Triad> = emptyArray()
 
     var particleGroupCount: Int = 0
         internal set
-    internal var m_groupList: ParticleGroup? = null
+    internal var groupList: ParticleGroup? = null
 
-    internal var m_pressureStrength: Float = 0.05f
+    internal var pressureStrength: Float = 0.05f
     var particleDamping: Float = 1f
-    internal var m_elasticStrength: Float = 0.25f
-    internal var m_springStrength: Float = 0.25f
-    internal var m_viscousStrength: Float = 0.25f
-    internal var m_surfaceTensionStrengthA: Float = 0.1f
-    internal var m_surfaceTensionStrengthB: Float = 0.2f
-    internal var m_powderStrength: Float = 0.5f
-    internal var m_ejectionStrength: Float = 0.5f
-    internal var m_colorMixingStrength: Float = 0.5f
+    internal var elasticStrength: Float = 0.25f
+    internal var springStrength: Float = 0.25f
+    internal var viscousStrength: Float = 0.25f
+    internal var surfaceTensionStrengthA: Float = 0.1f
+    internal var surfaceTensionStrengthB: Float = 0.2f
+    internal var powderStrength: Float = 0.5f
+    internal var ejectionStrength: Float = 0.5f
+    internal var colorMixingStrength: Float = 0.5f
 
     private val temp = AABB()
     private val dpcallback = DestroyParticlesInShapeCallback()
@@ -105,58 +105,58 @@ class ParticleSystem(internal var m_world: World) {
     private val newIndices = NewIndices()
 
     var particleDensity: Float
-        get() = m_density
+        get() = density
         set(density) {
-            m_density = density
-            m_inverseDensity = 1 / m_density
+            this.density = density
+            inverseDensity = 1 / this.density
         }
 
     var particleRadius: Float
-        get() = m_particleDiameter / 2
+        get() = particleDiameter / 2
         set(radius) {
-            m_particleDiameter = 2 * radius
-            m_squaredDiameter = m_particleDiameter * m_particleDiameter
-            m_inverseDiameter = 1 / m_particleDiameter
+            particleDiameter = 2 * radius
+            squaredDiameter = particleDiameter * particleDiameter
+            inverseDiameter = 1 / particleDiameter
         }
 
     internal val particleStride: Float
-        get() = Settings.particleStride * m_particleDiameter
+        get() = Settings.particleStride * particleDiameter
 
     internal val particleMass: Float
         get() {
             val stride = particleStride
-            return m_density * stride * stride
+            return density * stride * stride
         }
 
     internal val particleInvMass: Float
-        get() = 1.777777f * m_inverseDensity * m_inverseDiameter * m_inverseDiameter
+        get() = 1.777777f * inverseDensity * inverseDiameter * inverseDiameter
 
     val particleFlagsBuffer: IntArray?
-        get() = m_flagsBuffer.data
+        get() = flagsBuffer.data
 
     val particlePositionBuffer: Array<Vec2>?
-        get() = m_positionBuffer.data
+        get() = positionBuffer.data
 
     val particleVelocityBuffer: Array<Vec2>?
-        get() = m_velocityBuffer.data
+        get() = velocityBuffer.data
 
     val particleColorBuffer: Array<ParticleColor>?
         get() {
-            m_colorBuffer.data = requestParticleBuffer({ ParticleColor() }, m_colorBuffer.data)
-            return m_colorBuffer.data
+            colorBuffer.data = requestParticleBuffer({ ParticleColor() }, colorBuffer.data)
+            return colorBuffer.data
         }
 
     val particleUserDataBuffer: Array<Any>?
         get() {
-            m_userDataBuffer.data = requestParticleBuffer({ Any() }, m_userDataBuffer.data)
-            return m_userDataBuffer.data
+            userDataBuffer.data = requestParticleBuffer({ Any() }, userDataBuffer.data)
+            return userDataBuffer.data
         }
 
     var particleMaxCount: Int
-        get() = m_maxCount
+        get() = maxCount
         set(count) {
             assert(particleCount <= count)
-            m_maxCount = count
+            maxCount = count
         }
 
     //  public void assertNotSamePosition() {
@@ -170,74 +170,89 @@ class ParticleSystem(internal var m_world: World) {
     //  }
 
     fun createParticle(def: ParticleDef): Int {
-        if (particleCount >= m_internalAllocatedCapacity) {
+        if (particleCount >= internalAllocatedCapacity) {
             var capacity = if (particleCount != 0) 2 * particleCount else Settings.minParticleBufferCapacity
-            capacity = limitCapacity(capacity, m_maxCount)
-            capacity = limitCapacity(capacity, m_flagsBuffer.userSuppliedCapacity)
-            capacity = limitCapacity(capacity, m_positionBuffer.userSuppliedCapacity)
-            capacity = limitCapacity(capacity, m_velocityBuffer.userSuppliedCapacity)
-            capacity = limitCapacity(capacity, m_colorBuffer.userSuppliedCapacity)
-            capacity = limitCapacity(capacity, m_userDataBuffer.userSuppliedCapacity)
-            if (m_internalAllocatedCapacity < capacity) {
-                m_flagsBuffer.data = reallocateBuffer(m_flagsBuffer, m_internalAllocatedCapacity, capacity, false)
-                m_positionBuffer.data = reallocateBuffer(m_positionBuffer, m_internalAllocatedCapacity, capacity, false)
-                m_velocityBuffer.data = reallocateBuffer(m_velocityBuffer, m_internalAllocatedCapacity, capacity, false)
-                m_accumulationBuffer = BufferUtils.reallocateBuffer(m_accumulationBuffer, 0, m_internalAllocatedCapacity, capacity, false)
-                m_accumulation2Buffer = BufferUtils.reallocateBuffer({ Vec2() }, m_accumulation2Buffer, 0, m_internalAllocatedCapacity, capacity, true)
-                m_depthBuffer = BufferUtils.reallocateBuffer(m_depthBuffer, 0, m_internalAllocatedCapacity, capacity, true)
-                m_colorBuffer.data = reallocateBuffer(m_colorBuffer, m_internalAllocatedCapacity, capacity, true)
-                particleGroupBuffer = BufferUtils.reallocateBuffer<ParticleGroup>({ ParticleGroup() }, particleGroupBuffer as Array<ParticleGroup>, 0, m_internalAllocatedCapacity, capacity, false) as Array<ParticleGroup?>
-                m_userDataBuffer.data = reallocateBuffer(m_userDataBuffer, m_internalAllocatedCapacity, capacity, true)
-                m_internalAllocatedCapacity = capacity
+            capacity = limitCapacity(capacity, maxCount)
+            capacity = limitCapacity(capacity, flagsBuffer.userSuppliedCapacity)
+            capacity = limitCapacity(capacity, positionBuffer.userSuppliedCapacity)
+            capacity = limitCapacity(capacity, velocityBuffer.userSuppliedCapacity)
+            capacity = limitCapacity(capacity, colorBuffer.userSuppliedCapacity)
+            capacity = limitCapacity(capacity, userDataBuffer.userSuppliedCapacity)
+            if (internalAllocatedCapacity < capacity) {
+                flagsBuffer.data = reallocateBuffer(flagsBuffer, internalAllocatedCapacity, capacity, false)
+                positionBuffer.data = reallocateBuffer(positionBuffer, internalAllocatedCapacity, capacity, false)
+                velocityBuffer.data = reallocateBuffer(velocityBuffer, internalAllocatedCapacity, capacity, false)
+                accumulationBuffer =
+                    BufferUtils.reallocateBuffer(accumulationBuffer, 0, internalAllocatedCapacity, capacity, false)
+                accumulation2Buffer = BufferUtils.reallocateBuffer(
+                    { Vec2() },
+                    accumulation2Buffer,
+                    0,
+                    internalAllocatedCapacity,
+                    capacity,
+                    true
+                )
+                depthBuffer = BufferUtils.reallocateBuffer(depthBuffer, 0, internalAllocatedCapacity, capacity, true)
+                colorBuffer.data = reallocateBuffer(colorBuffer, internalAllocatedCapacity, capacity, true)
+                particleGroupBuffer = BufferUtils.reallocateBuffer<ParticleGroup>(
+                    { ParticleGroup() },
+                    particleGroupBuffer as Array<ParticleGroup>,
+                    0,
+                    internalAllocatedCapacity,
+                    capacity,
+                    false
+                ) as Array<ParticleGroup?>
+                userDataBuffer.data = reallocateBuffer(userDataBuffer, internalAllocatedCapacity, capacity, true)
+                internalAllocatedCapacity = capacity
             }
         }
-        if (particleCount >= m_internalAllocatedCapacity) {
+        if (particleCount >= internalAllocatedCapacity) {
             return Settings.invalidParticleIndex
         }
         val index = particleCount++
-        m_flagsBuffer!!.data!![index] = def.flags
-        m_positionBuffer.data!![index].set(def.position)
+        flagsBuffer.data!![index] = def.flags
+        positionBuffer.data!![index].set(def.position)
         //    assertNotSamePosition();
-        m_velocityBuffer.data!![index].set(def.velocity)
-        particleGroupBuffer!![index] = null
-        if (m_depthBuffer != null) {
-            m_depthBuffer!![index] = 0f
+        velocityBuffer.data!![index].set(def.velocity)
+        particleGroupBuffer[index] = null
+        if (depthBuffer != null) {
+            depthBuffer!![index] = 0f
         }
-        if (m_colorBuffer.data != null || def.color != null) {
-            m_colorBuffer.data = requestParticleBuffer(m_colorBuffer.dataClass, m_colorBuffer.data)
-            m_colorBuffer.data!![index].set(def.color!!)
+        if (colorBuffer.data != null || def.color != null) {
+            colorBuffer.data = requestParticleBuffer(colorBuffer.dataClass, colorBuffer.data)
+            colorBuffer.data!![index].set(def.color!!)
         }
-        if (m_userDataBuffer.data != null || def.userData != null) {
-            m_userDataBuffer.data = requestParticleBuffer(m_userDataBuffer.dataClass, m_userDataBuffer.data)
-            m_userDataBuffer.data!![index] = def.userData!!
+        if (userDataBuffer.data != null || def.userData != null) {
+            userDataBuffer.data = requestParticleBuffer(userDataBuffer.dataClass, userDataBuffer.data)
+            userDataBuffer.data!![index] = def.userData!!
         }
-        if (m_proxyCount >= m_proxyCapacity) {
-            val oldCapacity = m_proxyCapacity
-            val newCapacity = if (m_proxyCount != 0) 2 * m_proxyCount else Settings.minParticleBufferCapacity
-            m_proxyBuffer = BufferUtils.reallocateBuffer({ Proxy() }, m_proxyBuffer, oldCapacity, newCapacity)
-            m_proxyCapacity = newCapacity
+        if (proxyCount >= proxyCapacity) {
+            val oldCapacity = proxyCapacity
+            val newCapacity = if (proxyCount != 0) 2 * proxyCount else Settings.minParticleBufferCapacity
+            proxyBuffer = BufferUtils.reallocateBuffer({ Proxy() }, proxyBuffer, oldCapacity, newCapacity)
+            proxyCapacity = newCapacity
         }
-        m_proxyBuffer[m_proxyCount++].index = index
+        proxyBuffer[proxyCount++].index = index
         return index
     }
 
     fun destroyParticle(index: Int, callDestructionListener: Boolean) {
-        var flags = ParticleType.b2_zombieParticle
+        var flags = ParticleType.zombieParticle
         if (callDestructionListener) {
-            flags = flags or ParticleType.b2_destructionListener
+            flags = flags or ParticleType.destructionListener
         }
-        m_flagsBuffer!!.data!![index] = m_flagsBuffer!!.data!![index] or flags
+        flagsBuffer.data!![index] = flagsBuffer.data!![index] or flags
     }
 
     fun destroyParticlesInShape(shape: Shape, xf: Transform, callDestructionListener: Boolean): Int {
         dpcallback.init(this, shape, xf, callDestructionListener)
         shape.computeAABB(temp, xf, 0)
-        m_world.queryAABB(dpcallback, temp)
+        world.queryAABB(dpcallback, temp)
         return dpcallback.destroyed
     }
 
     fun destroyParticlesInGroup(group: ParticleGroup, callDestructionListener: Boolean) {
-        for (i in group.m_firstIndex until group.m_lastIndex) {
+        for (i in group.firstIndex until group.lastIndex) {
             destroyParticle(i, callDestructionListener)
         }
     }
@@ -293,29 +308,29 @@ class ParticleSystem(internal var m_world: World) {
         val lastIndex = particleCount
 
         val group = ParticleGroup()
-        group.m_system = this
-        group.m_firstIndex = firstIndex
-        group.m_lastIndex = lastIndex
-        group.m_groupFlags = groupDef.groupFlags
-        group.m_strength = groupDef.strength
-        group.m_userData = groupDef.userData
-        group.m_transform.set(transform)
-        group.m_destroyAutomatically = groupDef.destroyAutomatically
-        group.m_prev = null
-        group.m_next = m_groupList
-        if (m_groupList != null) {
-            m_groupList!!.m_prev = group
+        group.system = this
+        group.firstIndex = firstIndex
+        group.lastIndex = lastIndex
+        group.groupFlags = groupDef.groupFlags
+        group.strength = groupDef.strength
+        group.userData = groupDef.userData
+        group.transform.set(transform)
+        group.destroyAutomatically = groupDef.destroyAutomatically
+        group.prev = null
+        group.next = groupList
+        if (groupList != null) {
+            groupList!!.prev = group
         }
-        m_groupList = group
+        groupList = group
         ++particleGroupCount
         for (i in firstIndex until lastIndex) {
-            particleGroupBuffer!![i] = group
+            particleGroupBuffer[i] = group
         }
 
         updateContacts(true)
-        if (groupDef.flags and k_pairFlags != 0) {
-            for (k in 0 until m_contactCount) {
-                val contact = m_contactBuffer[k]
+        if (groupDef.flags and pairFlags != 0) {
+            for (k in 0 until contactCount) {
+                val contact = contactBuffer[k]
                 var a = contact.indexA
                 var b = contact.indexB
                 if (a > b) {
@@ -324,26 +339,26 @@ class ParticleSystem(internal var m_world: World) {
                     b = temp
                 }
                 if (firstIndex <= a && b < lastIndex) {
-                    if (m_pairCount >= m_pairCapacity) {
-                        val oldCapacity = m_pairCapacity
-                        val newCapacity = if (m_pairCount != 0) 2 * m_pairCount else Settings.minParticleBufferCapacity
-                        m_pairBuffer = BufferUtils.reallocateBuffer({ Pair() }, m_pairBuffer, oldCapacity, newCapacity)
-                        m_pairCapacity = newCapacity
+                    if (pairCount >= pairCapacity) {
+                        val oldCapacity = pairCapacity
+                        val newCapacity = if (pairCount != 0) 2 * pairCount else Settings.minParticleBufferCapacity
+                        pairBuffer = BufferUtils.reallocateBuffer({ Pair() }, pairBuffer, oldCapacity, newCapacity)
+                        pairCapacity = newCapacity
                     }
-                    val pair = m_pairBuffer[m_pairCount]
+                    val pair = pairBuffer[pairCount]
                     pair.indexA = a
                     pair.indexB = b
                     pair.flags = contact.flags
                     pair.strength = groupDef.strength
-                    pair.distance = MathUtils.distance(m_positionBuffer.data!![a], m_positionBuffer.data!![b])
-                    m_pairCount++
+                    pair.distance = MathUtils.distance(positionBuffer.data!![a], positionBuffer.data!![b])
+                    pairCount++
                 }
             }
         }
-        if (groupDef.flags and k_triadFlags != 0) {
+        if (groupDef.flags and triadFlags != 0) {
             val diagram = VoronoiDiagram(lastIndex - firstIndex)
             for (i in firstIndex until lastIndex) {
-                diagram.addGenerator(m_positionBuffer.data!![i], i)
+                diagram.addGenerator(positionBuffer.data!![i], i)
             }
             diagram.generate(stride / 2)
             createParticleGroupCallback.system = this
@@ -351,7 +366,7 @@ class ParticleSystem(internal var m_world: World) {
             createParticleGroupCallback.firstIndex = firstIndex
             diagram.getNodes(createParticleGroupCallback)
         }
-        if (groupDef.groupFlags and ParticleGroupType.b2_solidParticleGroup != 0) {
+        if (groupDef.groupFlags and ParticleGroupType.solidParticleGroup != 0) {
             computeDepthForGroup(group)
         }
 
@@ -360,20 +375,20 @@ class ParticleSystem(internal var m_world: World) {
 
     fun joinParticleGroups(groupA: ParticleGroup, groupB: ParticleGroup) {
         assert(groupA != groupB)
-        RotateBuffer(groupB.m_firstIndex, groupB.m_lastIndex, particleCount)
-        assert(groupB.m_lastIndex == particleCount)
-        RotateBuffer(groupA.m_firstIndex, groupA.m_lastIndex, groupB.m_firstIndex)
-        assert(groupA.m_lastIndex == groupB.m_firstIndex)
+        RotateBuffer(groupB.firstIndex, groupB.lastIndex, particleCount)
+        assert(groupB.lastIndex == particleCount)
+        RotateBuffer(groupA.firstIndex, groupA.lastIndex, groupB.firstIndex)
+        assert(groupA.lastIndex == groupB.firstIndex)
 
         var particleFlags = 0
-        for (i in groupA.m_firstIndex until groupB.m_lastIndex) {
-            particleFlags = particleFlags or m_flagsBuffer.data!![i]
+        for (i in groupA.firstIndex until groupB.lastIndex) {
+            particleFlags = particleFlags or flagsBuffer.data!![i]
         }
 
         updateContacts(true)
-        if (particleFlags and k_pairFlags != 0) {
-            for (k in 0 until m_contactCount) {
-                val contact = m_contactBuffer[k]
+        if (particleFlags and pairFlags != 0) {
+            for (k in 0 until contactCount) {
+                val contact = contactBuffer[k]
                 var a = contact.indexA
                 var b = contact.indexB
                 if (a > b) {
@@ -381,29 +396,30 @@ class ParticleSystem(internal var m_world: World) {
                     a = b
                     b = temp
                 }
-                if (groupA.m_firstIndex <= a && a < groupA.m_lastIndex && groupB.m_firstIndex <= b
-                        && b < groupB.m_lastIndex) {
-                    if (m_pairCount >= m_pairCapacity) {
-                        val oldCapacity = m_pairCapacity
-                        val newCapacity = if (m_pairCount != 0) 2 * m_pairCount else Settings.minParticleBufferCapacity
-                        m_pairBuffer = BufferUtils.reallocateBuffer({ Pair() }, m_pairBuffer, oldCapacity, newCapacity)
-                        m_pairCapacity = newCapacity
+                if (groupA.firstIndex <= a && a < groupA.lastIndex && groupB.firstIndex <= b
+                    && b < groupB.lastIndex
+                ) {
+                    if (pairCount >= pairCapacity) {
+                        val oldCapacity = pairCapacity
+                        val newCapacity = if (pairCount != 0) 2 * pairCount else Settings.minParticleBufferCapacity
+                        pairBuffer = BufferUtils.reallocateBuffer({ Pair() }, pairBuffer, oldCapacity, newCapacity)
+                        pairCapacity = newCapacity
                     }
-                    val pair = m_pairBuffer[m_pairCount]
+                    val pair = pairBuffer[pairCount]
                     pair.indexA = a
                     pair.indexB = b
                     pair.flags = contact.flags
-                    pair.strength = MathUtils.min(groupA.m_strength, groupB.m_strength)
-                    pair.distance = MathUtils.distance(m_positionBuffer.data!![a], m_positionBuffer.data!![b])
-                    m_pairCount++
+                    pair.strength = MathUtils.min(groupA.strength, groupB.strength)
+                    pair.distance = MathUtils.distance(positionBuffer.data!![a], positionBuffer.data!![b])
+                    pairCount++
                 }
             }
         }
-        if (particleFlags and k_triadFlags != 0) {
-            val diagram = VoronoiDiagram(groupB.m_lastIndex - groupA.m_firstIndex)
-            for (i in groupA.m_firstIndex until groupB.m_lastIndex) {
-                if (m_flagsBuffer.data!![i] and ParticleType.b2_zombieParticle == 0) {
-                    diagram.addGenerator(m_positionBuffer.data!![i], i)
+        if (particleFlags and triadFlags != 0) {
+            val diagram = VoronoiDiagram(groupB.lastIndex - groupA.firstIndex)
+            for (i in groupA.firstIndex until groupB.lastIndex) {
+                if (flagsBuffer.data!![i] and ParticleType.zombieParticle == 0) {
+                    diagram.addGenerator(positionBuffer.data!![i], i)
                 }
             }
             diagram.generate(particleStride / 2)
@@ -414,16 +430,16 @@ class ParticleSystem(internal var m_world: World) {
             diagram.getNodes(callback)
         }
 
-        for (i in groupB.m_firstIndex until groupB.m_lastIndex) {
-            particleGroupBuffer!![i] = groupA
+        for (i in groupB.firstIndex until groupB.lastIndex) {
+            particleGroupBuffer[i] = groupA
         }
-        val groupFlags = groupA.m_groupFlags or groupB.m_groupFlags
-        groupA.m_groupFlags = groupFlags
-        groupA.m_lastIndex = groupB.m_lastIndex
-        groupB.m_firstIndex = groupB.m_lastIndex
+        val groupFlags = groupA.groupFlags or groupB.groupFlags
+        groupA.groupFlags = groupFlags
+        groupA.lastIndex = groupB.lastIndex
+        groupB.firstIndex = groupB.lastIndex
         destroyParticleGroup(groupB)
 
-        if (groupFlags and ParticleGroupType.b2_solidParticleGroup != 0) {
+        if (groupFlags and ParticleGroupType.solidParticleGroup != 0) {
             computeDepthForGroup(groupA)
         }
     }
@@ -433,136 +449,138 @@ class ParticleSystem(internal var m_world: World) {
         assert(particleGroupCount > 0)
         assert(group != null)
 
-        if (m_world.particleDestructionListener != null) {
-            m_world.particleDestructionListener!!.sayGoodbye(group!!)
+        if (world.particleDestructionListener != null) {
+            world.particleDestructionListener!!.sayGoodbye(group!!)
         }
 
-        for (i in group!!.m_firstIndex until group.m_lastIndex) {
-            particleGroupBuffer!![i] = null
+        for (i in group!!.firstIndex until group.lastIndex) {
+            particleGroupBuffer[i] = null
         }
 
-        if (group.m_prev != null) {
-            group.m_prev!!.m_next = group.m_next
+        if (group.prev != null) {
+            group.prev!!.next = group.next
         }
-        if (group.m_next != null) {
-            group.m_next!!.m_prev = group.m_prev
+        if (group.next != null) {
+            group.next!!.prev = group.prev
         }
-        if (group == m_groupList) {
-            m_groupList = group.m_next
+        if (group == groupList) {
+            groupList = group.next
         }
 
         --particleGroupCount
     }
 
     fun computeDepthForGroup(group: ParticleGroup) {
-        for (i in group.m_firstIndex until group.m_lastIndex) {
-            m_accumulationBuffer!![i] = 0f
+        for (i in group.firstIndex until group.lastIndex) {
+            accumulationBuffer[i] = 0f
         }
-        for (k in 0 until m_contactCount) {
-            val contact = m_contactBuffer[k]
+        for (k in 0 until contactCount) {
+            val contact = contactBuffer[k]
             val a = contact.indexA
             val b = contact.indexB
-            if (a >= group.m_firstIndex && a < group.m_lastIndex && b >= group.m_firstIndex
-                    && b < group.m_lastIndex) {
+            if (a >= group.firstIndex && a < group.lastIndex && b >= group.firstIndex
+                && b < group.lastIndex
+            ) {
                 val w = contact.weight
-                m_accumulationBuffer!![a] += w
-                m_accumulationBuffer!![b] += w
+                accumulationBuffer[a] += w
+                accumulationBuffer[b] += w
             }
         }
-        m_depthBuffer = requestParticleBuffer(m_depthBuffer)
-        for (i in group.m_firstIndex until group.m_lastIndex) {
-            val w = m_accumulationBuffer!![i]
-            m_depthBuffer!![i] = if (w < 0.8f) 0f else Float.MAX_VALUE
+        depthBuffer = requestParticleBuffer(depthBuffer)
+        for (i in group.firstIndex until group.lastIndex) {
+            val w = accumulationBuffer[i]
+            depthBuffer!![i] = if (w < 0.8f) 0f else Float.MAX_VALUE
         }
         val interationCount = group.particleCount
         for (t in 0 until interationCount) {
             var updated = false
-            for (k in 0 until m_contactCount) {
-                val contact = m_contactBuffer[k]
+            for (k in 0 until contactCount) {
+                val contact = contactBuffer[k]
                 val a = contact.indexA
                 val b = contact.indexB
-                if (a >= group.m_firstIndex && a < group.m_lastIndex && b >= group.m_firstIndex
-                        && b < group.m_lastIndex) {
+                if (a >= group.firstIndex && a < group.lastIndex && b >= group.firstIndex
+                    && b < group.lastIndex
+                ) {
                     val r = 1 - contact.weight
-                    val ap0 = m_depthBuffer!![a]
-                    val bp0 = m_depthBuffer!![b]
+                    val ap0 = depthBuffer!![a]
+                    val bp0 = depthBuffer!![b]
                     val ap1 = bp0 + r
                     val bp1 = ap0 + r
                     if (ap0 > ap1) {
-                        m_depthBuffer!![a] = ap1
+                        depthBuffer!![a] = ap1
                         updated = true
                     }
                     if (bp0 > bp1) {
-                        m_depthBuffer!![b] = bp1
+                        depthBuffer!![b] = bp1
                         updated = true
                     }
                 }
             }
-            if (!updated) {
-                break
-            }
+            if (!updated) break
         }
-        for (i in group.m_firstIndex until group.m_lastIndex) {
-            val p = m_depthBuffer!![i]
+        for (i in group.firstIndex until group.lastIndex) {
+            val p = depthBuffer!![i]
             if (p < Float.MAX_VALUE) {
-                m_depthBuffer!![i] *= m_particleDiameter
+                depthBuffer!![i] *= particleDiameter
             } else {
-                m_depthBuffer!![i] = 0f
+                depthBuffer!![i] = 0f
             }
         }
     }
 
     fun addContact(a: Int, b: Int) {
         assert(a != b)
-        val pa = m_positionBuffer.data!![a]
-        val pb = m_positionBuffer.data!![b]
+        val pa = positionBuffer.data!![a]
+        val pb = positionBuffer.data!![b]
         val dx = pb.x - pa.x
         val dy = pb.y - pa.y
         val d2 = dx * dx + dy * dy
         //    assert(d2 != 0);
-        if (d2 < m_squaredDiameter) {
-            if (m_contactCount >= m_contactCapacity) {
-                val oldCapacity = m_contactCapacity
-                val newCapacity = if (m_contactCount != 0) 2 * m_contactCount else Settings.minParticleBufferCapacity
-                m_contactBuffer = BufferUtils.reallocateBuffer({ ParticleContact() }, m_contactBuffer, oldCapacity,
-                        newCapacity)
-                m_contactCapacity = newCapacity
+        if (d2 < squaredDiameter) {
+            if (contactCount >= contactCapacity) {
+                val oldCapacity = contactCapacity
+                val newCapacity = if (contactCount != 0) 2 * contactCount else Settings.minParticleBufferCapacity
+                contactBuffer = BufferUtils.reallocateBuffer(
+                    { ParticleContact() }, contactBuffer, oldCapacity,
+                    newCapacity
+                )
+                contactCapacity = newCapacity
             }
             val invD = if (d2 != 0f) MathUtils.sqrt(1 / d2) else Float.MAX_VALUE
-            val contact = m_contactBuffer[m_contactCount]
+            val contact = contactBuffer[contactCount]
             contact.indexA = a
             contact.indexB = b
-            contact.flags = m_flagsBuffer.data!![a] or m_flagsBuffer.data!![b]
-            contact.weight = 1 - d2 * invD * m_inverseDiameter
+            contact.flags = flagsBuffer.data!![a] or flagsBuffer.data!![b]
+            contact.weight = 1 - d2 * invD * inverseDiameter
             contact.normal.x = invD * dx
             contact.normal.y = invD * dy
-            m_contactCount++
+            contactCount++
         }
     }
 
     fun updateContacts(exceptZombie: Boolean) {
-        for (p in 0 until m_proxyCount) {
-            val proxy = m_proxyBuffer[p]
+        for (p in 0 until proxyCount) {
+            val proxy = proxyBuffer[p]
             val i = proxy.index
-            val pos = m_positionBuffer.data!![i]
-            proxy.tag = computeTag(m_inverseDiameter * pos.x, m_inverseDiameter * pos.y)
+            val pos = positionBuffer.data!![i]
+            proxy.tag = computeTag(inverseDiameter * pos.x, inverseDiameter * pos.y)
         }
-        Arrays_sort(m_proxyBuffer, 0, m_proxyCount)
-        m_contactCount = 0
+        Arrays_sort(proxyBuffer, 0, proxyCount)
+        contactCount = 0
         var c_index = 0
-        for (i in 0 until m_proxyCount) {
-            val a = m_proxyBuffer[i]
+        for (i in 0 until proxyCount) {
+            val a = proxyBuffer[i]
             val rightTag = computeRelativeTag(a.tag, 1, 0)
-            for (j in i + 1 until m_proxyCount) {
-                val b = m_proxyBuffer[j]
+            for (j in i + 1 until proxyCount) {
+                val b = proxyBuffer[j]
                 if (rightTag < b.tag) {
                     break
                 }
                 addContact(a.index, b.index)
             }
             val bottomLeftTag = computeRelativeTag(a.tag, -1, 1)
-            while (c_index < m_proxyCount) {
-                val c = m_proxyBuffer[c_index]
+            while (c_index < proxyCount) {
+                val c = proxyBuffer[c_index]
                 if (bottomLeftTag <= c.tag) {
                     break
                 }
@@ -570,8 +588,8 @@ class ParticleSystem(internal var m_world: World) {
             }
             val bottomRightTag = computeRelativeTag(a.tag, 1, 1)
 
-            for (b_index in c_index until m_proxyCount) {
-                val b = m_proxyBuffer[b_index]
+            for (b_index in c_index until proxyCount) {
+                val b = proxyBuffer[b_index]
                 if (bottomRightTag < b.tag) {
                     break
                 }
@@ -579,19 +597,19 @@ class ParticleSystem(internal var m_world: World) {
             }
         }
         if (exceptZombie) {
-            var j = m_contactCount
+            var j = contactCount
             var i = 0
             while (i < j) {
-                if (m_contactBuffer[i].flags and ParticleType.b2_zombieParticle != 0) {
+                if (contactBuffer[i].flags and ParticleType.zombieParticle != 0) {
                     --j
-                    val temp = m_contactBuffer[j]
-                    m_contactBuffer[j] = m_contactBuffer[i]
-                    m_contactBuffer[i] = temp
+                    val temp = contactBuffer[j]
+                    contactBuffer[j] = contactBuffer[i]
+                    contactBuffer[i] = temp
                     --i
                 }
                 i++
             }
-            m_contactCount = j
+            contactCount = j
         }
     }
 
@@ -602,18 +620,18 @@ class ParticleSystem(internal var m_world: World) {
         aabb.upperBound.x = -Float.MAX_VALUE
         aabb.upperBound.y = -Float.MAX_VALUE
         for (i in 0 until particleCount) {
-            val p = m_positionBuffer.data!![i]
+            val p = positionBuffer.data!![i]
             Vec2.minToOut(aabb.lowerBound, p, aabb.lowerBound)
             Vec2.maxToOut(aabb.upperBound, p, aabb.upperBound)
         }
-        aabb.lowerBound.x -= m_particleDiameter
-        aabb.lowerBound.y -= m_particleDiameter
-        aabb.upperBound.x += m_particleDiameter
-        aabb.upperBound.y += m_particleDiameter
-        m_bodyContactCount = 0
+        aabb.lowerBound.x -= particleDiameter
+        aabb.lowerBound.y -= particleDiameter
+        aabb.upperBound.x += particleDiameter
+        aabb.upperBound.y += particleDiameter
+        bodyContactCount = 0
 
         ubccallback.system = this
-        m_world.queryAABB(ubccallback, aabb)
+        world.queryAABB(ubccallback, aabb)
     }
 
     fun solveCollision(step: TimeStep) {
@@ -625,8 +643,8 @@ class ParticleSystem(internal var m_world: World) {
         upperBound.x = -Float.MAX_VALUE
         upperBound.y = -Float.MAX_VALUE
         for (i in 0 until particleCount) {
-            val v = m_velocityBuffer.data!![i]
-            val p1 = m_positionBuffer.data!![i]
+            val v = velocityBuffer.data!![i]
+            val p1 = positionBuffer.data!![i]
             val p1x = p1.x
             val p1y = p1.y
             val p2x = p1x + step.dt * v.x
@@ -642,35 +660,31 @@ class ParticleSystem(internal var m_world: World) {
         }
         sccallback.step = step
         sccallback.system = this
-        m_world.queryAABB(sccallback, aabb)
+        world.queryAABB(sccallback, aabb)
     }
 
     fun solve(step: TimeStep) {
-        ++m_timestamp
-        if (particleCount == 0) {
-            return
-        }
-        m_allParticleFlags = 0
+        ++timestamp
+        if (particleCount == 0) return
+        allParticleFlags = 0
         for (i in 0 until particleCount) {
-            m_allParticleFlags = m_allParticleFlags or m_flagsBuffer.data!![i]
+            allParticleFlags = allParticleFlags or flagsBuffer.data!![i]
         }
-        if (m_allParticleFlags and ParticleType.b2_zombieParticle != 0) {
+        if (allParticleFlags and ParticleType.zombieParticle != 0) {
             solveZombie()
         }
-        if (particleCount == 0) {
-            return
-        }
-        m_allGroupFlags = 0
-        var group = m_groupList
+        if (particleCount == 0) return
+        allGroupFlags = 0
+        var group = groupList
         while (group != null) {
-            m_allGroupFlags = m_allGroupFlags or group.m_groupFlags
-            group = group.getNext()
+            allGroupFlags = allGroupFlags or group.groupFlags
+            group = group.next
         }
-        val gravityx = step.dt * particleGravityScale * m_world.gravity.x
-        val gravityy = step.dt * particleGravityScale * m_world.gravity.y
+        val gravityx = step.dt * particleGravityScale * world.gravity.x
+        val gravityy = step.dt * particleGravityScale * world.gravity.y
         val criticalVelocytySquared = getCriticalVelocitySquared(step)
         for (i in 0 until particleCount) {
-            val v = m_velocityBuffer.data!![i]
+            val v = velocityBuffer.data!![i]
             v.x += gravityx
             v.y += gravityy
             val v2 = v.x * v.x + v.y * v.y
@@ -681,39 +695,39 @@ class ParticleSystem(internal var m_world: World) {
             }
         }
         solveCollision(step)
-        if (m_allGroupFlags and ParticleGroupType.b2_rigidParticleGroup != 0) {
+        if (allGroupFlags and ParticleGroupType.rigidParticleGroup != 0) {
             solveRigid(step)
         }
-        if (m_allParticleFlags and ParticleType.b2_wallParticle != 0) {
+        if (allParticleFlags and ParticleType.wallParticle != 0) {
             solveWall(step)
         }
         for (i in 0 until particleCount) {
-            val pos = m_positionBuffer.data!![i]
-            val vel = m_velocityBuffer.data!![i]
+            val pos = positionBuffer.data!![i]
+            val vel = velocityBuffer.data!![i]
             pos.x += step.dt * vel.x
             pos.y += step.dt * vel.y
         }
         updateBodyContacts()
         updateContacts(false)
-        if (m_allParticleFlags and ParticleType.b2_viscousParticle != 0) {
+        if (allParticleFlags and ParticleType.viscousParticle != 0) {
             solveViscous(step)
         }
-        if (m_allParticleFlags and ParticleType.b2_powderParticle != 0) {
+        if (allParticleFlags and ParticleType.powderParticle != 0) {
             solvePowder(step)
         }
-        if (m_allParticleFlags and ParticleType.b2_tensileParticle != 0) {
+        if (allParticleFlags and ParticleType.tensileParticle != 0) {
             solveTensile(step)
         }
-        if (m_allParticleFlags and ParticleType.b2_elasticParticle != 0) {
+        if (allParticleFlags and ParticleType.elasticParticle != 0) {
             solveElastic(step)
         }
-        if (m_allParticleFlags and ParticleType.b2_springParticle != 0) {
+        if (allParticleFlags and ParticleType.springParticle != 0) {
             solveSpring(step)
         }
-        if (m_allGroupFlags and ParticleGroupType.b2_solidParticleGroup != 0) {
+        if (allGroupFlags and ParticleGroupType.solidParticleGroup != 0) {
             solveSolid(step)
         }
-        if (m_allParticleFlags and ParticleType.b2_colorMixingParticle != 0) {
+        if (allParticleFlags and ParticleType.colorMixingParticle != 0) {
             solveColorMixing(step)
         }
         solvePressure(step)
@@ -724,69 +738,72 @@ class ParticleSystem(internal var m_world: World) {
         // calculates the sum of contact-weights for each particle
         // that means dimensionless density
         for (i in 0 until particleCount) {
-            m_accumulationBuffer[i] = 0f
+            accumulationBuffer[i] = 0f
         }
-        for (k in 0 until m_bodyContactCount) {
-            val contact = m_bodyContactBuffer[k]
+        for (k in 0 until bodyContactCount) {
+            val contact = bodyContactBuffer[k]
             val a = contact.index
             val w = contact.weight
-            m_accumulationBuffer[a] += w
+            accumulationBuffer[a] += w
         }
-        for (k in 0 until m_contactCount) {
-            val contact = m_contactBuffer[k]
+        for (k in 0 until contactCount) {
+            val contact = contactBuffer[k]
             val a = contact.indexA
             val b = contact.indexB
             val w = contact.weight
-            m_accumulationBuffer[a] += w
-            m_accumulationBuffer[b] += w
+            accumulationBuffer[a] += w
+            accumulationBuffer[b] += w
         }
         // ignores powder particles
-        if (m_allParticleFlags and k_noPressureFlags != 0) {
+        if (allParticleFlags and noPressureFlags != 0) {
             for (i in 0 until particleCount) {
-                if (m_flagsBuffer.data!![i] and k_noPressureFlags != 0) {
-                    m_accumulationBuffer[i] = 0f
+                if (flagsBuffer.data!![i] and noPressureFlags != 0) {
+                    accumulationBuffer[i] = 0f
                 }
             }
         }
         // calculates pressure as a linear function of density
-        val pressurePerWeight = m_pressureStrength * getCriticalPressure(step)
+        val pressurePerWeight = pressureStrength * getCriticalPressure(step)
         for (i in 0 until particleCount) {
-            val w = m_accumulationBuffer!![i]
-            val h = pressurePerWeight * MathUtils.max(0.0f, MathUtils.min(w, Settings.maxParticleWeight) - Settings.minParticleWeight)
-            m_accumulationBuffer[i] = h
+            val w = accumulationBuffer[i]
+            val h = pressurePerWeight * MathUtils.max(
+                0.0f,
+                MathUtils.min(w, Settings.maxParticleWeight) - Settings.minParticleWeight
+            )
+            accumulationBuffer[i] = h
         }
         // applies pressure between each particles in contact
-        val velocityPerPressure = step.dt / (m_density * m_particleDiameter)
-        for (k in 0 until m_bodyContactCount) {
-            val contact = m_bodyContactBuffer[k]
+        val velocityPerPressure = step.dt / (density * particleDiameter)
+        for (k in 0 until bodyContactCount) {
+            val contact = bodyContactBuffer[k]
             val a = contact.index
             val b = contact.body
             val w = contact.weight
             val m = contact.mass
             val n = contact.normal
-            val p = m_positionBuffer.data!![a]
-            val h = m_accumulationBuffer!![a] + pressurePerWeight * w
+            val p = positionBuffer.data!![a]
+            val h = accumulationBuffer[a] + pressurePerWeight * w
             val f = tempVec
             val coef = velocityPerPressure * w * m * h
             f.x = coef * n.x
             f.y = coef * n.y
-            val velData = m_velocityBuffer.data!![a]
+            val velData = velocityBuffer.data!![a]
             val particleInvMass = particleInvMass
             velData.x -= particleInvMass * f.x
             velData.y -= particleInvMass * f.y
             b!!.applyLinearImpulse(f, p, true)
         }
-        for (k in 0 until m_contactCount) {
-            val contact = m_contactBuffer[k]
+        for (k in 0 until contactCount) {
+            val contact = contactBuffer[k]
             val a = contact.indexA
             val b = contact.indexB
             val w = contact.weight
             val n = contact.normal
-            val h = m_accumulationBuffer!![a] + m_accumulationBuffer!![b]
+            val h = accumulationBuffer[a] + accumulationBuffer[b]
             val fx = velocityPerPressure * w * h * n.x
             val fy = velocityPerPressure * w * h * n.y
-            val velDataA = m_velocityBuffer.data!![a]
-            val velDataB = m_velocityBuffer.data!![b]
+            val velDataA = velocityBuffer.data!![a]
+            val velDataB = velocityBuffer.data!![b]
             velDataA.x -= fx
             velDataA.y -= fy
             velDataB.x += fx
@@ -797,20 +814,20 @@ class ParticleSystem(internal var m_world: World) {
     internal fun solveDamping(step: TimeStep) {
         // reduces normal velocity of each contact
         val damping = particleDamping
-        for (k in 0 until m_bodyContactCount) {
-            val contact = m_bodyContactBuffer[k]
+        for (k in 0 until bodyContactCount) {
+            val contact = bodyContactBuffer[k]
             val a = contact.index
             val b = contact.body
             val w = contact.weight
             val m = contact.mass
             val n = contact.normal
-            val p = m_positionBuffer.data!![a]
-            val tempX = p.x - b!!.m_sweep.c.x
-            val tempY = p.y - b!!.m_sweep.c.y
-            val velA = m_velocityBuffer.data!![a]
+            val p = positionBuffer.data!![a]
+            val tempX = p.x - b!!.sweep.c.x
+            val tempY = p.y - b.sweep.c.y
+            val velA = velocityBuffer.data!![a]
             // getLinearVelocityFromWorldPointToOut, with -= velA
-            val vx = -b!!.m_angularVelocity * tempY + b!!.m_linearVelocity.x - velA.x
-            val vy = b!!.m_angularVelocity * tempX + b!!.m_linearVelocity.y - velA.y
+            val vx = -b._angularVelocity * tempY + b._linearVelocity.x - velA.x
+            val vy = b._angularVelocity * tempX + b._linearVelocity.y - velA.y
             // done
             val vn = vx * n.x + vy * n.y
             if (vn < 0) {
@@ -822,17 +839,17 @@ class ParticleSystem(internal var m_world: World) {
                 velA.y += invMass * f.y
                 f.x = -f.x
                 f.y = -f.y
-                b!!.applyLinearImpulse(f, p, true)
+                b.applyLinearImpulse(f, p, true)
             }
         }
-        for (k in 0 until m_contactCount) {
-            val contact = m_contactBuffer[k]
+        for (k in 0 until contactCount) {
+            val contact = contactBuffer[k]
             val a = contact.indexA
             val b = contact.indexB
             val w = contact.weight
             val n = contact.normal
-            val velA = m_velocityBuffer.data!![a]
-            val velB = m_velocityBuffer.data!![b]
+            val velA = velocityBuffer.data!![a]
+            val velB = velocityBuffer.data!![b]
             val vx = velB.x - velA.x
             val vy = velB.y - velA.y
             val vn = vx * n.x + vy * n.y
@@ -849,8 +866,8 @@ class ParticleSystem(internal var m_world: World) {
 
     fun solveWall(step: TimeStep) {
         for (i in 0 until particleCount) {
-            if (m_flagsBuffer.data!![i] and ParticleType.b2_wallParticle != 0) {
-                val r = m_velocityBuffer.data!![i]
+            if (flagsBuffer.data!![i] and ParticleType.wallParticle != 0) {
+                val r = velocityBuffer.data!![i]
                 r.x = 0.0f
                 r.y = 0.0f
             }
@@ -858,47 +875,50 @@ class ParticleSystem(internal var m_world: World) {
     }
 
     internal fun solveRigid(step: TimeStep) {
-        var group = m_groupList
+        var group = groupList
         while (group != null) {
-            if (group.m_groupFlags and ParticleGroupType.b2_rigidParticleGroup != 0) {
+            if (group.groupFlags and ParticleGroupType.rigidParticleGroup != 0) {
                 group.updateStatistics()
                 val temp = tempVec
                 val cross = tempVec2
                 val rotation = tempRot
-                rotation.setRadians(step.dt * group.m_angularVelocity)
-                Rot.mulToOutUnsafe(rotation, group.m_center, cross)
-                temp.set(group.m_linearVelocity).mulLocal(step.dt).addLocal(group.m_center).subLocal(cross)
+                rotation.setRadians(step.dt * group._angularVelocity)
+                Rot.mulToOutUnsafe(rotation, group._center, cross)
+                temp.set(group._linearVelocity).mulLocal(step.dt).addLocal(group._center).subLocal(cross)
                 tempXf.p.set(temp)
                 tempXf.q.set(rotation)
-                Transform.mulToOut(tempXf, group.m_transform, group.m_transform)
+                Transform.mulToOut(tempXf, group.transform, group.transform)
                 val velocityTransform = tempXf2
-                velocityTransform.p.x = step.inv_dt * tempXf.p.x
-                velocityTransform.p.y = step.inv_dt * tempXf.p.y
-                velocityTransform.q.s = step.inv_dt * tempXf.q.s
-                velocityTransform.q.c = step.inv_dt * (tempXf.q.c - 1)
-                for (i in group.m_firstIndex until group.m_lastIndex) {
-                    Transform.mulToOutUnsafe(velocityTransform, m_positionBuffer.data!![i],
-                            m_velocityBuffer.data!![i])
+                velocityTransform.p.x = step.invDt * tempXf.p.x
+                velocityTransform.p.y = step.invDt * tempXf.p.y
+                velocityTransform.q.s = step.invDt * tempXf.q.s
+                velocityTransform.q.c = step.invDt * (tempXf.q.c - 1)
+                for (i in group.firstIndex until group.lastIndex) {
+                    Transform.mulToOutUnsafe(
+                        velocityTransform,
+                        positionBuffer.data!![i],
+                        velocityBuffer.data!![i]
+                    )
                 }
             }
-            group = group.getNext()
+            group = group.next
         }
     }
 
     internal fun solveElastic(step: TimeStep) {
-        val elasticStrength = step.inv_dt * m_elasticStrength
-        for (k in 0 until m_triadCount) {
-            val triad = m_triadBuffer[k]
-            if (triad.flags and ParticleType.b2_elasticParticle != 0) {
+        val elasticStrength = step.invDt * elasticStrength
+        for (k in 0 until triadCount) {
+            val triad = triadBuffer[k]
+            if (triad.flags and ParticleType.elasticParticle != 0) {
                 val a = triad.indexA
                 val b = triad.indexB
                 val c = triad.indexC
                 val oa = triad.pa
                 val ob = triad.pb
                 val oc = triad.pc
-                val pa = m_positionBuffer.data!![a]
-                val pb = m_positionBuffer.data!![b]
-                val pc = m_positionBuffer.data!![c]
+                val pa = positionBuffer.data!![a]
+                val pb = positionBuffer.data!![b]
+                val pc = positionBuffer.data!![c]
                 val px = 1f / 3 * (pa.x + pb.x + pc.x)
                 val py = 1f / 3 * (pa.y + pb.y + pc.y)
                 var rs = Vec2.cross(oa, pa) + Vec2.cross(ob, pb) + Vec2.cross(oc, pc)
@@ -914,9 +934,9 @@ class ParticleSystem(internal var m_world: World) {
                 val roby = rs * ob.x + rc * ob.y
                 val rocx = rc * oc.x - rs * oc.y
                 val rocy = rs * oc.x + rc * oc.y
-                val va = m_velocityBuffer.data!![a]
-                val vb = m_velocityBuffer.data!![b]
-                val vc = m_velocityBuffer.data!![c]
+                val va = velocityBuffer.data!![a]
+                val vb = velocityBuffer.data!![b]
+                val vc = velocityBuffer.data!![c]
                 va.x += strength * (roax - (pa.x - px))
                 va.y += strength * (roay - (pa.y - py))
                 vb.x += strength * (robx - (pb.x - px))
@@ -928,14 +948,14 @@ class ParticleSystem(internal var m_world: World) {
     }
 
     internal fun solveSpring(step: TimeStep) {
-        val springStrength = step.inv_dt * m_springStrength
-        for (k in 0 until m_pairCount) {
-            val pair = m_pairBuffer[k]
-            if (pair.flags and ParticleType.b2_springParticle != 0) {
+        val springStrength = step.invDt * springStrength
+        for (k in 0 until pairCount) {
+            val pair = pairBuffer[k]
+            if (pair.flags and ParticleType.springParticle != 0) {
                 val a = pair.indexA
                 val b = pair.indexB
-                val pa = m_positionBuffer.data!![a]
-                val pb = m_positionBuffer.data!![b]
+                val pa = positionBuffer.data!![a]
+                val pb = positionBuffer.data!![b]
                 val dx = pb.x - pa.x
                 val dy = pb.y - pa.y
                 val r0 = pair.distance
@@ -944,8 +964,8 @@ class ParticleSystem(internal var m_world: World) {
                 val strength = springStrength * pair.strength
                 val fx = strength * (r0 - r1) / r1 * dx
                 val fy = strength * (r0 - r1) / r1 * dy
-                val va = m_velocityBuffer.data!![a]
-                val vb = m_velocityBuffer.data!![b]
+                val va = velocityBuffer.data!![a]
+                val vb = velocityBuffer.data!![b]
                 va.x -= fx
                 va.y -= fy
                 vb.x += fx
@@ -955,22 +975,22 @@ class ParticleSystem(internal var m_world: World) {
     }
 
     internal fun solveTensile(step: TimeStep) {
-        m_accumulation2Buffer = requestParticleBuffer({ Vec2() }, m_accumulation2Buffer)
+        accumulation2Buffer = requestParticleBuffer({ Vec2() }, accumulation2Buffer)
         for (i in 0 until particleCount) {
-            m_accumulationBuffer[i] = 0f
-            m_accumulation2Buffer!![i].setZero()
+            accumulationBuffer[i] = 0f
+            accumulation2Buffer[i].setZero()
         }
-        for (k in 0 until m_contactCount) {
-            val contact = m_contactBuffer[k]
-            if (contact.flags and ParticleType.b2_tensileParticle != 0) {
+        for (k in 0 until contactCount) {
+            val contact = contactBuffer[k]
+            if (contact.flags and ParticleType.tensileParticle != 0) {
                 val a = contact.indexA
                 val b = contact.indexB
                 val w = contact.weight
                 val n = contact.normal
-                m_accumulationBuffer[a] += w
-                m_accumulationBuffer[b] += w
-                val a2A = m_accumulation2Buffer!![a]
-                val a2B = m_accumulation2Buffer!![b]
+                accumulationBuffer[a] += w
+                accumulationBuffer[b] += w
+                val a2A = accumulation2Buffer[a]
+                val a2B = accumulation2Buffer[b]
                 val inter = (1 - w) * w
                 a2A.x -= inter * n.x
                 a2A.y -= inter * n.y
@@ -978,25 +998,25 @@ class ParticleSystem(internal var m_world: World) {
                 a2B.y += inter * n.y
             }
         }
-        val strengthA = m_surfaceTensionStrengthA * getCriticalVelocity(step)
-        val strengthB = m_surfaceTensionStrengthB * getCriticalVelocity(step)
-        for (k in 0 until m_contactCount) {
-            val contact = m_contactBuffer[k]
-            if (contact.flags and ParticleType.b2_tensileParticle != 0) {
+        val strengthA = surfaceTensionStrengthA * getCriticalVelocity(step)
+        val strengthB = surfaceTensionStrengthB * getCriticalVelocity(step)
+        for (k in 0 until contactCount) {
+            val contact = contactBuffer[k]
+            if (contact.flags and ParticleType.tensileParticle != 0) {
                 val a = contact.indexA
                 val b = contact.indexB
                 val w = contact.weight
                 val n = contact.normal
-                val a2A = m_accumulation2Buffer!![a]
-                val a2B = m_accumulation2Buffer!![b]
-                val h = m_accumulationBuffer!![a] + m_accumulationBuffer!![b]
+                val a2A = accumulation2Buffer[a]
+                val a2B = accumulation2Buffer[b]
+                val h = accumulationBuffer[a] + accumulationBuffer[b]
                 val sx = a2B.x - a2A.x
                 val sy = a2B.y - a2A.y
                 val fn = (strengthA * (h - 2) + strengthB * (sx * n.x + sy * n.y)) * w
                 val fx = fn * n.x
                 val fy = fn * n.y
-                val va = m_velocityBuffer.data!![a]
-                val vb = m_velocityBuffer.data!![b]
+                val va = velocityBuffer.data!![a]
+                val vb = velocityBuffer.data!![b]
                 va.x -= fx
                 va.y -= fy
                 vb.x += fx
@@ -1006,20 +1026,20 @@ class ParticleSystem(internal var m_world: World) {
     }
 
     internal fun solveViscous(step: TimeStep) {
-        val viscousStrength = m_viscousStrength
-        for (k in 0 until m_bodyContactCount) {
-            val contact = m_bodyContactBuffer[k]
+        val viscousStrength = viscousStrength
+        for (k in 0 until bodyContactCount) {
+            val contact = bodyContactBuffer[k]
             val a = contact.index
-            if (m_flagsBuffer.data!![a] and ParticleType.b2_viscousParticle != 0) {
+            if (flagsBuffer.data!![a] and ParticleType.viscousParticle != 0) {
                 val b = contact.body
                 val w = contact.weight
                 val m = contact.mass
-                val p = m_positionBuffer.data!![a]
-                val va = m_velocityBuffer.data!![a]
-                val tempX = p.x - b!!.m_sweep.c.x
-                val tempY = p.y - b!!.m_sweep.c.y
-                val vx = -b!!.m_angularVelocity * tempY + b!!.m_linearVelocity.x - va.x
-                val vy = b!!.m_angularVelocity * tempX + b!!.m_linearVelocity.y - va.y
+                val p = positionBuffer.data!![a]
+                val va = velocityBuffer.data!![a]
+                val tempX = p.x - b!!.sweep.c.x
+                val tempY = p.y - b.sweep.c.y
+                val vx = -b._angularVelocity * tempY + b._linearVelocity.x - va.x
+                val vy = b._angularVelocity * tempX + b._linearVelocity.y - va.y
                 val f = tempVec
                 val pInvMass = particleInvMass
                 f.x = viscousStrength * m * w * vx
@@ -1028,17 +1048,17 @@ class ParticleSystem(internal var m_world: World) {
                 va.y += pInvMass * f.y
                 f.x = -f.x
                 f.y = -f.y
-                b!!.applyLinearImpulse(f, p, true)
+                b.applyLinearImpulse(f, p, true)
             }
         }
-        for (k in 0 until m_contactCount) {
-            val contact = m_contactBuffer[k]
-            if (contact.flags and ParticleType.b2_viscousParticle != 0) {
+        for (k in 0 until contactCount) {
+            val contact = contactBuffer[k]
+            if (contact.flags and ParticleType.viscousParticle != 0) {
                 val a = contact.indexA
                 val b = contact.indexB
                 val w = contact.weight
-                val va = m_velocityBuffer.data!![a]
-                val vb = m_velocityBuffer.data!![b]
+                val va = velocityBuffer.data!![a]
+                val vb = velocityBuffer.data!![b]
                 val vx = vb.x - va.x
                 val vy = vb.y - va.y
                 val fx = viscousStrength * w * vx
@@ -1052,20 +1072,20 @@ class ParticleSystem(internal var m_world: World) {
     }
 
     internal fun solvePowder(step: TimeStep) {
-        val powderStrength = m_powderStrength * getCriticalVelocity(step)
+        val powderStrength = powderStrength * getCriticalVelocity(step)
         val minWeight = 1.0f - Settings.particleStride
-        for (k in 0 until m_bodyContactCount) {
-            val contact = m_bodyContactBuffer[k]
+        for (k in 0 until bodyContactCount) {
+            val contact = bodyContactBuffer[k]
             val a = contact.index
-            if (m_flagsBuffer.data!![a] and ParticleType.b2_powderParticle != 0) {
+            if (flagsBuffer.data!![a] and ParticleType.powderParticle != 0) {
                 val w = contact.weight
                 if (w > minWeight) {
                     val b = contact.body
                     val m = contact.mass
-                    val p = m_positionBuffer.data!![a]
+                    val p = positionBuffer.data!![a]
                     val n = contact.normal
                     val f = tempVec
-                    val va = m_velocityBuffer.data!![a]
+                    val va = velocityBuffer.data!![a]
                     val inter = powderStrength * m * (w - minWeight)
                     val pInvMass = particleInvMass
                     f.x = inter * n.x
@@ -1076,16 +1096,16 @@ class ParticleSystem(internal var m_world: World) {
                 }
             }
         }
-        for (k in 0 until m_contactCount) {
-            val contact = m_contactBuffer[k]
-            if (contact.flags and ParticleType.b2_powderParticle != 0) {
+        for (k in 0 until contactCount) {
+            val contact = contactBuffer[k]
+            if (contact.flags and ParticleType.powderParticle != 0) {
                 val w = contact.weight
                 if (w > minWeight) {
                     val a = contact.indexA
                     val b = contact.indexB
                     val n = contact.normal
-                    val va = m_velocityBuffer.data!![a]
-                    val vb = m_velocityBuffer.data!![b]
+                    val va = velocityBuffer.data!![a]
+                    val vb = velocityBuffer.data!![b]
                     val inter = powderStrength * (w - minWeight)
                     val fx = inter * n.x
                     val fy = inter * n.y
@@ -1100,18 +1120,18 @@ class ParticleSystem(internal var m_world: World) {
 
     internal fun solveSolid(step: TimeStep) {
         // applies extra repulsive force from solid particle groups
-        m_depthBuffer = requestParticleBuffer(m_depthBuffer)
-        val ejectionStrength = step.inv_dt * m_ejectionStrength
-        for (k in 0 until m_contactCount) {
-            val contact = m_contactBuffer[k]
+        depthBuffer = requestParticleBuffer(depthBuffer)
+        val ejectionStrength = step.invDt * ejectionStrength
+        for (k in 0 until contactCount) {
+            val contact = contactBuffer[k]
             val a = contact.indexA
             val b = contact.indexB
-            if (particleGroupBuffer!![a] != particleGroupBuffer!![b]) {
+            if (particleGroupBuffer[a] != particleGroupBuffer[b]) {
                 val w = contact.weight
                 val n = contact.normal
-                val h = m_depthBuffer!![a] + m_depthBuffer!![b]
-                val va = m_velocityBuffer.data!![a]
-                val vb = m_velocityBuffer.data!![b]
+                val h = depthBuffer!![a] + depthBuffer!![b]
+                val va = velocityBuffer.data!![a]
+                val vb = velocityBuffer.data!![b]
                 val inter = ejectionStrength * h * w
                 val fx = inter * n.x
                 val fy = inter * n.y
@@ -1125,15 +1145,15 @@ class ParticleSystem(internal var m_world: World) {
 
     internal fun solveColorMixing(step: TimeStep) {
         // mixes color between contacting particles
-        m_colorBuffer.data = requestParticleBuffer({ ParticleColor() }, m_colorBuffer.data)
-        val colorMixing256 = (256 * m_colorMixingStrength).toInt()
-        for (k in 0 until m_contactCount) {
-            val contact = m_contactBuffer[k]
+        colorBuffer.data = requestParticleBuffer({ ParticleColor() }, colorBuffer.data)
+        val colorMixing256 = (256 * colorMixingStrength).toInt()
+        for (k in 0 until contactCount) {
+            val contact = contactBuffer[k]
             val a = contact.indexA
             val b = contact.indexB
-            if (m_flagsBuffer.data!![a] and m_flagsBuffer.data!![b] and ParticleType.b2_colorMixingParticle != 0) {
-                val colorA = m_colorBuffer.data!![a]!!
-                val colorB = m_colorBuffer.data!![b]!!
+            if (flagsBuffer.data!![a] and flagsBuffer.data!![b] and ParticleType.colorMixingParticle != 0) {
+                val colorA = colorBuffer.data!![a]
+                val colorB = colorBuffer.data!![b]
                 val dr = (colorMixing256 * ((colorB.r.toInt() and 0xFF) - (colorA.r.toInt() and 0xFF))) ushr 8
                 val dg = (colorMixing256 * ((colorB.g.toInt() and 0xFF) - (colorA.g.toInt() and 0xFF))) ushr 8
                 val db = (colorMixing256 * ((colorB.b.toInt() and 0xFF) - (colorA.b.toInt() and 0xFF))) ushr 8
@@ -1155,28 +1175,28 @@ class ParticleSystem(internal var m_world: World) {
         var newCount = 0
         val newIndices = IntArray(particleCount)
         for (i in 0 until particleCount) {
-            val flags = m_flagsBuffer.data!![i]
-            if (flags and ParticleType.b2_zombieParticle != 0) {
-                val destructionListener = m_world.particleDestructionListener
-                if (flags and ParticleType.b2_destructionListener != 0 && destructionListener != null) {
+            val flags = flagsBuffer.data!![i]
+            if (flags and ParticleType.zombieParticle != 0) {
+                val destructionListener = world.particleDestructionListener
+                if (flags and ParticleType.destructionListener != 0 && destructionListener != null) {
                     destructionListener.sayGoodbye(i)
                 }
                 newIndices[i] = Settings.invalidParticleIndex
             } else {
                 newIndices[i] = newCount
                 if (i != newCount) {
-                    m_flagsBuffer!!.data!![newCount] = m_flagsBuffer.data!![i]
-                    m_positionBuffer.data!![newCount].set(m_positionBuffer.data!![i])
-                    m_velocityBuffer.data!![newCount].set(m_velocityBuffer.data!![i])
-                    particleGroupBuffer!!.set(newCount, particleGroupBuffer!![i]!!)
-                    if (m_depthBuffer != null) {
-                        m_depthBuffer!![newCount] = m_depthBuffer!![i]
+                    flagsBuffer.data!![newCount] = flagsBuffer.data!![i]
+                    positionBuffer.data!![newCount].set(positionBuffer.data!![i])
+                    velocityBuffer.data!![newCount].set(velocityBuffer.data!![i])
+                    particleGroupBuffer.set(newCount, particleGroupBuffer[i]!!)
+                    if (depthBuffer != null) {
+                        depthBuffer!![newCount] = depthBuffer!![i]
                     }
-                    if (m_colorBuffer.data != null) {
-                        m_colorBuffer.data!![newCount].set(m_colorBuffer.data!![i])
+                    if (colorBuffer.data != null) {
+                        colorBuffer.data!![newCount].set(colorBuffer.data!![i])
                     }
-                    if (m_userDataBuffer.data != null) {
-                        m_userDataBuffer!!.data!![newCount] = m_userDataBuffer.data!![i]
+                    if (userDataBuffer.data != null) {
+                        userDataBuffer!!.data!![newCount] = userDataBuffer.data!![i]
                     }
                 }
                 newCount++
@@ -1184,8 +1204,8 @@ class ParticleSystem(internal var m_world: World) {
         }
 
         // update proxies
-        for (k in 0 until m_proxyCount) {
-            val proxy = m_proxyBuffer[k]
+        for (k in 0 until proxyCount) {
+            val proxy = proxyBuffer[k]
             proxy.index = newIndices[proxy.index]
         }
 
@@ -1193,25 +1213,25 @@ class ParticleSystem(internal var m_world: World) {
         // m_proxyBuffer, m_proxyBuffer + m_proxyCount,
         // Test.IsProxyInvalid);
         // m_proxyCount = (int) (lastProxy - m_proxyBuffer);
-        var j = m_proxyCount
+        var j = proxyCount
         run {
             var i = 0
             while (i < j) {
-                if (Test.IsProxyInvalid(m_proxyBuffer[i])) {
+                if (Test.IsProxyInvalid(proxyBuffer[i])) {
                     --j
-                    val temp = m_proxyBuffer[j]
-                    m_proxyBuffer[j] = m_proxyBuffer[i]
-                    m_proxyBuffer[i] = temp
+                    val temp = proxyBuffer[j]
+                    proxyBuffer[j] = proxyBuffer[i]
+                    proxyBuffer[i] = temp
                     --i
                 }
                 i++
             }
         }
-        m_proxyCount = j
+        proxyCount = j
 
         // update contacts
-        for (k in 0 until m_contactCount) {
-            val contact = m_contactBuffer[k]
+        for (k in 0 until contactCount) {
+            val contact = contactBuffer[k]
             contact.indexA = newIndices[contact.indexA]
             contact.indexB = newIndices[contact.indexB]
         }
@@ -1219,74 +1239,74 @@ class ParticleSystem(internal var m_world: World) {
         // m_contactBuffer, m_contactBuffer + m_contactCount,
         // Test.IsContactInvalid);
         // m_contactCount = (int) (lastContact - m_contactBuffer);
-        j = m_contactCount
+        j = contactCount
         run {
             var i = 0
             while (i < j) {
-                if (Test.IsContactInvalid(m_contactBuffer[i])) {
+                if (Test.IsContactInvalid(contactBuffer[i])) {
                     --j
-                    val temp = m_contactBuffer[j]
-                    m_contactBuffer[j] = m_contactBuffer[i]
-                    m_contactBuffer[i] = temp
+                    val temp = contactBuffer[j]
+                    contactBuffer[j] = contactBuffer[i]
+                    contactBuffer[i] = temp
                     --i
                 }
                 i++
             }
         }
-        m_contactCount = j
+        contactCount = j
 
         // update particle-body contacts
-        for (k in 0 until m_bodyContactCount) {
-            val contact = m_bodyContactBuffer[k]
+        for (k in 0 until bodyContactCount) {
+            val contact = bodyContactBuffer[k]
             contact.index = newIndices[contact.index]
         }
         // ParticleBodyContact lastBodyContact = std.remove_if(
         // m_bodyContactBuffer, m_bodyContactBuffer + m_bodyContactCount,
         // Test.IsBodyContactInvalid);
         // m_bodyContactCount = (int) (lastBodyContact - m_bodyContactBuffer);
-        j = m_bodyContactCount
+        j = bodyContactCount
         run {
             var i = 0
             while (i < j) {
-                if (Test.IsBodyContactInvalid(m_bodyContactBuffer[i])) {
+                if (Test.IsBodyContactInvalid(bodyContactBuffer[i])) {
                     --j
-                    val temp = m_bodyContactBuffer[j]
-                    m_bodyContactBuffer[j] = m_bodyContactBuffer[i]
-                    m_bodyContactBuffer[i] = temp
+                    val temp = bodyContactBuffer[j]
+                    bodyContactBuffer[j] = bodyContactBuffer[i]
+                    bodyContactBuffer[i] = temp
                     --i
                 }
                 i++
             }
         }
-        m_bodyContactCount = j
+        bodyContactCount = j
 
         // update pairs
-        for (k in 0 until m_pairCount) {
-            val pair = m_pairBuffer[k]
+        for (k in 0 until pairCount) {
+            val pair = pairBuffer[k]
             pair.indexA = newIndices[pair.indexA]
             pair.indexB = newIndices[pair.indexB]
         }
         // Pair lastPair = std.remove_if(m_pairBuffer, m_pairBuffer + m_pairCount, Test.IsPairInvalid);
         // m_pairCount = (int) (lastPair - m_pairBuffer);
-        j = m_pairCount
+        j = pairCount
         run {
             var i = 0
             while (i < j) {
-                if (Test.IsPairInvalid(m_pairBuffer[i])) {
+                if (Test.IsPairInvalid(pairBuffer[i])) {
                     --j
-                    val temp = m_pairBuffer[j]
-                    m_pairBuffer[j] = m_pairBuffer[i]
-                    m_pairBuffer[i] = temp
+                    val temp = pairBuffer[j]
+                    pairBuffer[j] = pairBuffer[i]
+                    pairBuffer[i] = temp
                     --i
                 }
                 i++
             }
         }
-        m_pairCount = j
+        pairCount = j
 
         // update triads
-        for (k in 0 until m_triadCount) {
-            val triad = m_triadBuffer[k]
+        for (k in 0 until triadCount) {
+            val triad = triadBuffer[k]
             triad.indexA = newIndices[triad.indexA]
             triad.indexB = newIndices[triad.indexB]
             triad.indexC = newIndices[triad.indexC]
@@ -1294,30 +1314,30 @@ class ParticleSystem(internal var m_world: World) {
         // Triad lastTriad =
         // std.remove_if(m_triadBuffer, m_triadBuffer + m_triadCount, Test.isTriadInvalid);
         // m_triadCount = (int) (lastTriad - m_triadBuffer);
-        j = m_triadCount
+        j = triadCount
         run {
             var i = 0
             while (i < j) {
-                if (Test.IsTriadInvalid(m_triadBuffer[i])) {
+                if (Test.IsTriadInvalid(triadBuffer[i])) {
                     --j
-                    val temp = m_triadBuffer[j]
-                    m_triadBuffer[j] = m_triadBuffer[i]
-                    m_triadBuffer[i] = temp
+                    val temp = triadBuffer[j]
+                    triadBuffer[j] = triadBuffer[i]
+                    triadBuffer[i] = temp
                     --i
                 }
                 i++
             }
         }
-        m_triadCount = j
+        triadCount = j
 
         // update groups
         run {
-            var group = m_groupList
+            var group = groupList
             while (group != null) {
                 var firstIndex = newCount
                 var lastIndex = 0
                 var modified = false
-                for (i in group!!.m_firstIndex until group!!.m_lastIndex) {
+                for (i in group!!.firstIndex until group!!.lastIndex) {
                     j = newIndices[i]
                     if (j >= 0) {
                         firstIndex = MathUtils.min(firstIndex, j)
@@ -1327,21 +1347,21 @@ class ParticleSystem(internal var m_world: World) {
                     }
                 }
                 if (firstIndex < lastIndex) {
-                    group!!.m_firstIndex = firstIndex
-                    group!!.m_lastIndex = lastIndex
+                    group!!.firstIndex = firstIndex
+                    group!!.lastIndex = lastIndex
                     if (modified) {
-                        if (group!!.m_groupFlags and ParticleGroupType.b2_rigidParticleGroup != 0) {
-                            group!!.m_toBeSplit = true
+                        if (group!!.groupFlags and ParticleGroupType.rigidParticleGroup != 0) {
+                            group!!.toBeSplit = true
                         }
                     }
                 } else {
-                    group!!.m_firstIndex = 0
-                    group!!.m_lastIndex = 0
-                    if (group!!.m_destroyAutomatically) {
-                        group!!.m_toBeDestroyed = true
+                    group!!.firstIndex = 0
+                    group!!.lastIndex = 0
+                    if (group!!.destroyAutomatically) {
+                        group!!.toBeDestroyed = true
                     }
                 }
-                group = group!!.getNext()
+                group = group!!.next
             }
         }
 
@@ -1350,12 +1370,12 @@ class ParticleSystem(internal var m_world: World) {
         // m_world.m_stackAllocator.Free(newIndices);
 
         // destroy bodies with no particles
-        var group = m_groupList
+        var group = groupList
         while (group != null) {
-            val next = group!!.getNext()
-            if (group!!.m_toBeDestroyed) {
+            val next = group!!.next
+            if (group!!.toBeDestroyed) {
                 destroyParticleGroup(group)
-            } else if (group!!.m_toBeSplit) {
+            } else if (group!!.toBeSplit) {
                 // TODO: split the group
             }
             group = next
@@ -1367,88 +1387,80 @@ class ParticleSystem(internal var m_world: World) {
         internal var mid: Int = 0
         internal var end: Int = 0
 
-        internal fun getIndex(i: Int): Int {
-            return if (i < start) {
-                i
-            } else if (i < mid) {
-                i + end - mid
-            } else if (i < end) {
-                i + start - mid
-            } else {
-                i
-            }
+        internal fun getIndex(i: Int) = when {
+            i < start -> i
+            i < mid -> i + end - mid
+            i < end -> i + start - mid
+            else -> i
         }
     }
 
-
     internal fun RotateBuffer(start: Int, mid: Int, end: Int) {
         // move the particles assigned to the given group toward the end of array
-        if (start == mid || mid == end) {
-            return
-        }
+        if (start == mid || mid == end) return
         newIndices.start = start
         newIndices.mid = mid
         newIndices.end = end
 
-        BufferUtils.rotate(m_flagsBuffer.data!!, start, mid, end)
-        BufferUtils.rotate<Vec2>(m_positionBuffer.data!!, start, mid, end)
-        BufferUtils.rotate<Vec2>(m_velocityBuffer.data!!, start, mid, end)
-        BufferUtils.rotate<ParticleGroup>(particleGroupBuffer!! as Array<ParticleGroup>, start, mid, end)
-        if (m_depthBuffer != null) {
-            BufferUtils.rotate(m_depthBuffer!!, start, mid, end)
+        BufferUtils.rotate(flagsBuffer.data!!, start, mid, end)
+        BufferUtils.rotate(positionBuffer.data!!, start, mid, end)
+        BufferUtils.rotate(velocityBuffer.data!!, start, mid, end)
+        BufferUtils.rotate(particleGroupBuffer as Array<ParticleGroup>, start, mid, end)
+        if (depthBuffer != null) {
+            BufferUtils.rotate(depthBuffer!!, start, mid, end)
         }
-        if (m_colorBuffer.data != null) {
-            BufferUtils.rotate<ParticleColor>(m_colorBuffer.data!!, start, mid, end)
+        if (colorBuffer.data != null) {
+            BufferUtils.rotate(colorBuffer.data!!, start, mid, end)
         }
-        if (m_userDataBuffer.data != null) {
-            BufferUtils.rotate<Any>(m_userDataBuffer.data!!, start, mid, end)
+        if (userDataBuffer.data != null) {
+            BufferUtils.rotate(userDataBuffer.data!!, start, mid, end)
         }
 
         // update proxies
-        for (k in 0 until m_proxyCount) {
-            val proxy = m_proxyBuffer[k]
+        for (k in 0 until proxyCount) {
+            val proxy = proxyBuffer[k]
             proxy.index = newIndices.getIndex(proxy.index)
         }
 
         // update contacts
-        for (k in 0 until m_contactCount) {
-            val contact = m_contactBuffer[k]
+        for (k in 0 until contactCount) {
+            val contact = contactBuffer[k]
             contact.indexA = newIndices.getIndex(contact.indexA)
             contact.indexB = newIndices.getIndex(contact.indexB)
         }
 
         // update particle-body contacts
-        for (k in 0 until m_bodyContactCount) {
-            val contact = m_bodyContactBuffer[k]
+        for (k in 0 until bodyContactCount) {
+            val contact = bodyContactBuffer[k]
             contact.index = newIndices.getIndex(contact.index)
         }
 
         // update pairs
-        for (k in 0 until m_pairCount) {
-            val pair = m_pairBuffer[k]
+        for (k in 0 until pairCount) {
+            val pair = pairBuffer[k]
             pair.indexA = newIndices.getIndex(pair.indexA)
             pair.indexB = newIndices.getIndex(pair.indexB)
         }
 
         // update triads
-        for (k in 0 until m_triadCount) {
-            val triad = m_triadBuffer[k]
+        for (k in 0 until triadCount) {
+            val triad = triadBuffer[k]
             triad.indexA = newIndices.getIndex(triad.indexA)
             triad.indexB = newIndices.getIndex(triad.indexB)
             triad.indexC = newIndices.getIndex(triad.indexC)
         }
 
         // update groups
-        var group = m_groupList
+        var group = groupList
         while (group != null) {
-            group.m_firstIndex = newIndices.getIndex(group.m_firstIndex)
-            group.m_lastIndex = newIndices.getIndex(group.m_lastIndex - 1) + 1
-            group = group.getNext()
+            group.firstIndex = newIndices.getIndex(group.firstIndex)
+            group.lastIndex = newIndices.getIndex(group.lastIndex - 1) + 1
+            group = group.next
         }
     }
 
     internal fun getCriticalVelocity(step: TimeStep): Float {
-        return m_particleDiameter * step.inv_dt
+        return particleDiameter * step.invDt
     }
 
     internal fun getCriticalVelocitySquared(step: TimeStep): Float {
@@ -1457,7 +1469,7 @@ class ParticleSystem(internal var m_world: World) {
     }
 
     internal fun getCriticalPressure(step: TimeStep): Float {
-        return m_density * getCriticalVelocitySquared(step)
+        return density * getCriticalVelocitySquared(step)
     }
 
     internal fun setParticleBuffer(buffer: ParticleBufferInt, newData: IntArray?, newCapacity: Int) {
@@ -1479,45 +1491,47 @@ class ParticleSystem(internal var m_world: World) {
     }
 
     fun setParticleFlagsBuffer(buffer: IntArray, capacity: Int) {
-        setParticleBuffer(m_flagsBuffer, buffer, capacity)
+        setParticleBuffer(flagsBuffer, buffer, capacity)
     }
 
     fun setParticlePositionBuffer(buffer: Array<Vec2>, capacity: Int) {
-        setParticleBuffer(m_positionBuffer, buffer, capacity)
+        setParticleBuffer(positionBuffer, buffer, capacity)
     }
 
     fun setParticleVelocityBuffer(buffer: Array<Vec2>, capacity: Int) {
-        setParticleBuffer(m_velocityBuffer, buffer, capacity)
+        setParticleBuffer(velocityBuffer, buffer, capacity)
     }
 
     fun setParticleColorBuffer(buffer: Array<ParticleColor>, capacity: Int) {
-        setParticleBuffer(m_colorBuffer, buffer, capacity)
+        setParticleBuffer(colorBuffer, buffer, capacity)
     }
 
     fun getParticleGroupList(): Array<ParticleGroup?>? {
-        return particleGroupBuffer!!
+        return particleGroupBuffer
     }
 
     fun setParticleUserDataBuffer(buffer: Array<Any>, capacity: Int) {
-        setParticleBuffer(m_userDataBuffer, buffer, capacity)
+        setParticleBuffer(userDataBuffer, buffer, capacity)
     }
 
     fun queryAABB(callback: ParticleQueryCallback, aabb: AABB) {
-        if (m_proxyCount == 0) {
-            return
-        }
+        if (proxyCount == 0) return
 
         val lowerBoundX = aabb.lowerBound.x
         val lowerBoundY = aabb.lowerBound.y
         val upperBoundX = aabb.upperBound.x
         val upperBoundY = aabb.upperBound.y
-        val firstProxy = lowerBound(m_proxyBuffer, m_proxyCount,
-                computeTag(m_inverseDiameter * lowerBoundX, m_inverseDiameter * lowerBoundY))
-        val lastProxy = upperBound(m_proxyBuffer, m_proxyCount,
-                computeTag(m_inverseDiameter * upperBoundX, m_inverseDiameter * upperBoundY))
+        val firstProxy = lowerBound(
+            proxyBuffer, proxyCount,
+            computeTag(inverseDiameter * lowerBoundX, inverseDiameter * lowerBoundY)
+        )
+        val lastProxy = upperBound(
+            proxyBuffer, proxyCount,
+            computeTag(inverseDiameter * upperBoundX, inverseDiameter * upperBoundY)
+        )
         for (proxy in firstProxy until lastProxy) {
-            val i = m_proxyBuffer[proxy].index
-            val p = m_positionBuffer.data!![i]
+            val i = proxyBuffer[proxy].index
+            val p = positionBuffer.data!![i]
             if (lowerBoundX < p.x && p.x < upperBoundX && lowerBoundY < p.y && p.y < upperBoundY) {
                 if (!callback.reportParticle(i)) {
                     break
@@ -1526,23 +1540,24 @@ class ParticleSystem(internal var m_world: World) {
         }
     }
 
-    /**
-     * @param callback
-     * @param point1
-     * @param point2
-     */
     fun raycast(callback: ParticleRaycastCallback, point1: Vec2, point2: Vec2) {
-        if (m_proxyCount == 0) {
-            return
-        }
+        if (proxyCount == 0) return
         val firstProxy = lowerBound(
-                m_proxyBuffer,
-                m_proxyCount,
-                computeTag(m_inverseDiameter * MathUtils.min(point1.x, point2.x) - 1, m_inverseDiameter * MathUtils.min(point1.y, point2.y) - 1))
+            proxyBuffer,
+            proxyCount,
+            computeTag(
+                inverseDiameter * MathUtils.min(point1.x, point2.x) - 1,
+                inverseDiameter * MathUtils.min(point1.y, point2.y) - 1
+            )
+        )
         val lastProxy = upperBound(
-                m_proxyBuffer,
-                m_proxyCount,
-                computeTag(m_inverseDiameter * MathUtils.max(point1.x, point2.x) + 1, m_inverseDiameter * MathUtils.max(point1.y, point2.y) + 1))
+            proxyBuffer,
+            proxyCount,
+            computeTag(
+                inverseDiameter * MathUtils.max(point1.x, point2.x) + 1,
+                inverseDiameter * MathUtils.max(point1.y, point2.y) + 1
+            )
+        )
         var fraction = 1f
         // solving the following equation:
         // ((1-t)*point1+t*point2-position)^2=diameter^2
@@ -1552,13 +1567,13 @@ class ParticleSystem(internal var m_world: World) {
         var v2 = vx * vx + vy * vy
         if (v2 == 0f) v2 = Float.MAX_VALUE
         for (proxy in firstProxy until lastProxy) {
-            val i = m_proxyBuffer[proxy].index
-            val posI = m_positionBuffer.data!![i]
+            val i = proxyBuffer[proxy].index
+            val posI = positionBuffer.data!![i]
             val px = point1.x - posI.x
             val py = point1.y - posI.y
             val pv = px * vx + py * vy
             val p2 = px * px + py * py
-            val determinant = pv * pv - v2 * (p2 - m_squaredDiameter)
+            val determinant = pv * pv - v2 * (p2 - squaredDiameter)
             if (determinant >= 0) {
                 val sqrtDeterminant = MathUtils.sqrt(determinant)
                 // find a solution between 0 and fraction
@@ -1590,13 +1605,13 @@ class ParticleSystem(internal var m_world: World) {
 
     fun computeParticleCollisionEnergy(): Float {
         var sum_v2 = 0f
-        for (k in 0 until m_contactCount) {
-            val contact = m_contactBuffer[k]
+        for (k in 0 until contactCount) {
+            val contact = contactBuffer[k]
             val a = contact.indexA
             val b = contact.indexB
             val n = contact.normal
-            val va = m_velocityBuffer.data!![a]
-            val vb = m_velocityBuffer.data!![b]
+            val va = velocityBuffer.data!![a]
+            val vb = velocityBuffer.data!![b]
             val vx = vb.x - va.x
             val vy = vb.y - va.y
             val vn = vx * n.x + vy * n.y
@@ -1610,7 +1625,7 @@ class ParticleSystem(internal var m_world: World) {
     internal fun <T : Any> requestParticleBuffer(newInstance: () -> T, buffer: Array<T>?): Array<T> {
         var buffer = buffer
         if (buffer == null) {
-            buffer = Array<Any>(m_internalAllocatedCapacity) { newInstance() } as Array<T>
+            buffer = Array<Any>(internalAllocatedCapacity) { newInstance() } as Array<T>
         }
         return buffer
     }
@@ -1618,7 +1633,7 @@ class ParticleSystem(internal var m_world: World) {
     internal fun requestParticleBuffer(buffer: FloatArray?): FloatArray {
         var buffer = buffer
         if (buffer == null) {
-            buffer = FloatArray(m_internalAllocatedCapacity)
+            buffer = FloatArray(internalAllocatedCapacity)
         }
         return buffer
     }
@@ -1638,16 +1653,16 @@ class ParticleSystem(internal var m_world: World) {
         internal var index: Int = 0
         internal var tag: Long = 0
 
-        override fun compareTo(o: Proxy): Int {
-            return if (tag - o.tag < 0) -1 else if (o.tag == tag) 0 else 1
+        override fun compareTo(other: Proxy): Int {
+            return if (tag - other.tag < 0) -1 else if (other.tag == tag) 0 else 1
         }
 
-        override fun equals(obj: Any?): Boolean {
-            if (this === obj) return true
-            if (obj == null) return false
-            if (this::class != obj::class) return false
-            val other = obj as Proxy?
-            return if (tag != other!!.tag) false else true
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other == null) return false
+            if (this::class != other::class) return false
+            val oth = other as Proxy?
+            return tag == oth!!.tag
         }
     }
 
@@ -1656,8 +1671,8 @@ class ParticleSystem(internal var m_world: World) {
         internal var indexA: Int = 0
         internal var indexB: Int = 0
         internal var flags: Int = 0
-        internal var strength: Float = 0.toFloat()
-        internal var distance: Float = 0.toFloat()
+        internal var strength: Float = 0f
+        internal var distance: Float = 0f
     }
 
     /** Connection between three particles  */
@@ -1666,14 +1681,14 @@ class ParticleSystem(internal var m_world: World) {
         internal var indexB: Int = 0
         internal var indexC: Int = 0
         internal var flags: Int = 0
-        internal var strength: Float = 0.toFloat()
+        internal var strength: Float = 0f
         internal val pa = Vec2()
         internal val pb = Vec2()
         internal val pc = Vec2()
-        internal var ka: Float = 0.toFloat()
-        internal var kb: Float = 0.toFloat()
-        internal var kc: Float = 0.toFloat()
-        internal var s: Float = 0.toFloat()
+        internal var ka: Float = 0f
+        internal var kb: Float = 0f
+        internal var kc: Float = 0f
+        internal var s: Float = 0f
     }
 
     // Callback used with VoronoiDiagram.
@@ -1683,35 +1698,38 @@ class ParticleSystem(internal var m_world: World) {
         var def: ParticleGroupDef? = null // pointer
         var firstIndex: Int = 0
         override fun callback(a: Int, b: Int, c: Int) {
-            val pa = system!!.m_positionBuffer.data!![a]
-            val pb = system!!.m_positionBuffer.data!![b]
-            val pc = system!!.m_positionBuffer.data!![c]
+            val pa = system!!.positionBuffer.data!![a]
+            val pb = system!!.positionBuffer.data!![b]
+            val pc = system!!.positionBuffer.data!![c]
             val dabx = pa.x - pb.x
             val daby = pa.y - pb.y
             val dbcx = pb.x - pc.x
             val dbcy = pb.y - pc.y
             val dcax = pc.x - pa.x
             val dcay = pc.y - pa.y
-            val maxDistanceSquared = Settings.maxTriadDistanceSquared * system!!.m_squaredDiameter
+            val maxDistanceSquared = Settings.maxTriadDistanceSquared * system!!.squaredDiameter
             if (dabx * dabx + daby * daby < maxDistanceSquared
-                    && dbcx * dbcx + dbcy * dbcy < maxDistanceSquared
-                    && dcax * dcax + dcay * dcay < maxDistanceSquared) {
-                if (system!!.m_triadCount >= system!!.m_triadCapacity) {
-                    val oldCapacity = system!!.m_triadCapacity
-                    val newCapacity = if (system!!.m_triadCount != 0)
-                        2 * system!!.m_triadCount
+                && dbcx * dbcx + dbcy * dbcy < maxDistanceSquared
+                && dcax * dcax + dcay * dcay < maxDistanceSquared
+            ) {
+                if (system!!.triadCount >= system!!.triadCapacity) {
+                    val oldCapacity = system!!.triadCapacity
+                    val newCapacity = if (system!!.triadCount != 0)
+                        2 * system!!.triadCount
                     else
                         Settings.minParticleBufferCapacity
-                    system!!.m_triadBuffer = BufferUtils.reallocateBuffer({ Triad() }, system!!.m_triadBuffer, oldCapacity,
-                            newCapacity)
-                    system!!.m_triadCapacity = newCapacity
+                    system!!.triadBuffer = BufferUtils.reallocateBuffer(
+                        { Triad() }, system!!.triadBuffer, oldCapacity,
+                        newCapacity
+                    )
+                    system!!.triadCapacity = newCapacity
                 }
-                val triad = system!!.m_triadBuffer[system!!.m_triadCount]
+                val triad = system!!.triadBuffer[system!!.triadCount]
                 triad.indexA = a
                 triad.indexB = b
                 triad.indexC = c
-                triad.flags = (system!!.m_flagsBuffer.data!![a] or system!!.m_flagsBuffer.data!![b]
-                        or system!!.m_flagsBuffer.data!![c])
+                triad.flags = (system!!.flagsBuffer.data!![a] or system!!.flagsBuffer.data!![b]
+                    or system!!.flagsBuffer.data!![c])
                 triad.strength = def!!.strength
                 val midPointx = 1.toFloat() / 3 * (pa.x + pb.x + pc.x)
                 val midPointy = 1.toFloat() / 3 * (pa.y + pb.y + pc.y)
@@ -1725,7 +1743,7 @@ class ParticleSystem(internal var m_world: World) {
                 triad.kb = -(dabx * dbcx + daby * dbcy)
                 triad.kc = -(dbcx * dcax + dbcy * dcay)
                 triad.s = Vec2.cross(pa, pb) + Vec2.cross(pb, pc) + Vec2.cross(pc, pa)
-                system!!.m_triadCount++
+                system!!.triadCount++
             }
         }
     }
@@ -1738,42 +1756,45 @@ class ParticleSystem(internal var m_world: World) {
         var groupB: ParticleGroup? = null
         override fun callback(a: Int, b: Int, c: Int) {
             // Create a triad if it will contain particles from both groups.
-            val countA = ((if (a < groupB!!.m_firstIndex) 1 else 0) + (if (b < groupB!!.m_firstIndex) 1 else 0)
-                    + if (c < groupB!!.m_firstIndex) 1 else 0)
+            val countA = ((if (a < groupB!!.firstIndex) 1 else 0) + (if (b < groupB!!.firstIndex) 1 else 0)
+                + if (c < groupB!!.firstIndex) 1 else 0)
             if (countA > 0 && countA < 3) {
-                val af = system!!.m_flagsBuffer.data!![a]
-                val bf = system!!.m_flagsBuffer.data!![b]
-                val cf = system!!.m_flagsBuffer.data!![c]
-                if (af and bf and cf and k_triadFlags != 0) {
-                    val pa = system!!.m_positionBuffer.data!![a]
-                    val pb = system!!.m_positionBuffer.data!![b]
-                    val pc = system!!.m_positionBuffer.data!![c]
+                val af = system!!.flagsBuffer.data!![a]
+                val bf = system!!.flagsBuffer.data!![b]
+                val cf = system!!.flagsBuffer.data!![c]
+                if (af and bf and cf and triadFlags != 0) {
+                    val pa = system!!.positionBuffer.data!![a]
+                    val pb = system!!.positionBuffer.data!![b]
+                    val pc = system!!.positionBuffer.data!![c]
                     val dabx = pa.x - pb.x
                     val daby = pa.y - pb.y
                     val dbcx = pb.x - pc.x
                     val dbcy = pb.y - pc.y
                     val dcax = pc.x - pa.x
                     val dcay = pc.y - pa.y
-                    val maxDistanceSquared = Settings.maxTriadDistanceSquared * system!!.m_squaredDiameter
+                    val maxDistanceSquared = Settings.maxTriadDistanceSquared * system!!.squaredDiameter
                     if (dabx * dabx + daby * daby < maxDistanceSquared
-                            && dbcx * dbcx + dbcy * dbcy < maxDistanceSquared
-                            && dcax * dcax + dcay * dcay < maxDistanceSquared) {
-                        if (system!!.m_triadCount >= system!!.m_triadCapacity) {
-                            val oldCapacity = system!!.m_triadCapacity
-                            val newCapacity = if (system!!.m_triadCount != 0)
-                                2 * system!!.m_triadCount
+                        && dbcx * dbcx + dbcy * dbcy < maxDistanceSquared
+                        && dcax * dcax + dcay * dcay < maxDistanceSquared
+                    ) {
+                        if (system!!.triadCount >= system!!.triadCapacity) {
+                            val oldCapacity = system!!.triadCapacity
+                            val newCapacity = if (system!!.triadCount != 0)
+                                2 * system!!.triadCount
                             else
                                 Settings.minParticleBufferCapacity
-                            system!!.m_triadBuffer = BufferUtils.reallocateBuffer({ Triad() }, system!!.m_triadBuffer, oldCapacity,
-                                    newCapacity)
-                            system!!.m_triadCapacity = newCapacity
+                            system!!.triadBuffer = BufferUtils.reallocateBuffer(
+                                { Triad() }, system!!.triadBuffer, oldCapacity,
+                                newCapacity
+                            )
+                            system!!.triadCapacity = newCapacity
                         }
-                        val triad = system!!.m_triadBuffer[system!!.m_triadCount]
+                        val triad = system!!.triadBuffer[system!!.triadCount]
                         triad.indexA = a
                         triad.indexB = b
                         triad.indexC = c
                         triad.flags = af or bf or cf
-                        triad.strength = MathUtils.min(groupA!!.m_strength, groupB!!.m_strength)
+                        triad.strength = MathUtils.min(groupA!!.strength, groupB!!.strength)
                         val midPointx = 1.toFloat() / 3 * (pa.x + pb.x + pc.x)
                         val midPointy = 1.toFloat() / 3 * (pa.y + pb.y + pc.y)
                         triad.pa.x = pa.x - midPointx
@@ -1786,7 +1807,7 @@ class ParticleSystem(internal var m_world: World) {
                         triad.kb = -(dabx * dbcx + daby * dbcy)
                         triad.kc = -(dbcx * dcax + dbcy * dcay)
                         triad.s = Vec2.cross(pa, pb) + Vec2.cross(pb, pc) + Vec2.cross(pc, pa)
-                        system!!.m_triadCount++
+                        system!!.triadCount++
                     }
                 }
             }
@@ -1800,8 +1821,10 @@ class ParticleSystem(internal var m_world: World) {
         var callDestructionListener: Boolean = false
         var destroyed: Int = 0
 
-        fun init(system: ParticleSystem, shape: Shape, xf: Transform,
-                 callDestructionListener: Boolean) {
+        fun init(
+            system: ParticleSystem, shape: Shape, xf: Transform,
+            callDestructionListener: Boolean
+        ) {
             this.system = system
             this.shape = shape
             this.xf = xf
@@ -1811,13 +1834,13 @@ class ParticleSystem(internal var m_world: World) {
 
         override fun reportParticle(index: Int): Boolean {
             assert(index >= 0 && index < system.particleCount)
-            if (shape.testPoint(xf, system.m_positionBuffer.data!![index])) {
+            if (shape.testPoint(xf, system.positionBuffer.data!![index])) {
                 system.destroyParticle(index, callDestructionListener)
                 destroyed++
             }
             return true
         }
-    }// TODO Auto-generated constructor stub
+    }
 
     internal class UpdateBodyContactsCallback : QueryCallback {
         var system: ParticleSystem? = null
@@ -1828,63 +1851,68 @@ class ParticleSystem(internal var m_world: World) {
             if (fixture.isSensor) {
                 return true
             }
-            val shape = fixture.getShape()
-            val b = fixture.getBody()
+            val shape = fixture.shape
+            val b = fixture.body
             val bp = b!!.worldCenter
-            val bm = b.getMass()
+            val bm = b.mass
             val bI = b.inertia - bm * b.localCenter.lengthSquared()
             val invBm = if (bm > 0) 1f / bm else 0f
             val invBI = if (bI > 0) 1f / bI else 0f
             val childCount = shape!!.getChildCount()
             for (childIndex in 0 until childCount) {
                 val aabb = fixture.getAABB(childIndex)
-                val aabblowerBoundx = aabb.lowerBound.x - system!!.m_particleDiameter
-                val aabblowerBoundy = aabb.lowerBound.y - system!!.m_particleDiameter
-                val aabbupperBoundx = aabb.upperBound.x + system!!.m_particleDiameter
-                val aabbupperBoundy = aabb.upperBound.y + system!!.m_particleDiameter
+                val aabblowerBoundx = aabb.lowerBound.x - system!!.particleDiameter
+                val aabblowerBoundy = aabb.lowerBound.y - system!!.particleDiameter
+                val aabbupperBoundx = aabb.upperBound.x + system!!.particleDiameter
+                val aabbupperBoundy = aabb.upperBound.y + system!!.particleDiameter
                 val firstProxy = lowerBound(
-                        system!!.m_proxyBuffer,
-                        system!!.m_proxyCount,
-                        computeTag(system!!.m_inverseDiameter * aabblowerBoundx, system!!.m_inverseDiameter * aabblowerBoundy))
+                    system!!.proxyBuffer,
+                    system!!.proxyCount,
+                    computeTag(system!!.inverseDiameter * aabblowerBoundx, system!!.inverseDiameter * aabblowerBoundy)
+                )
                 val lastProxy = upperBound(
-                        system!!.m_proxyBuffer,
-                        system!!.m_proxyCount,
-                        computeTag(system!!.m_inverseDiameter * aabbupperBoundx, system!!.m_inverseDiameter * aabbupperBoundy))
+                    system!!.proxyBuffer,
+                    system!!.proxyCount,
+                    computeTag(system!!.inverseDiameter * aabbupperBoundx, system!!.inverseDiameter * aabbupperBoundy)
+                )
 
                 for (proxy in firstProxy until lastProxy) {
-                    val a = system!!.m_proxyBuffer[proxy].index
-                    val ap = system!!.m_positionBuffer.data!![a]
+                    val a = system!!.proxyBuffer[proxy].index
+                    val ap = system!!.positionBuffer.data!![a]
                     if (aabblowerBoundx <= ap.x && ap.x <= aabbupperBoundx && aabblowerBoundy <= ap.y
-                            && ap.y <= aabbupperBoundy) {
+                        && ap.y <= aabbupperBoundy
+                    ) {
                         val d: Float
                         val n = tempVec
                         d = fixture.computeDistance(ap, childIndex, n)
-                        if (d < system!!.m_particleDiameter) {
-                            val invAm = if (system!!.m_flagsBuffer.data!![a] and ParticleType.b2_wallParticle != 0)
+                        if (d < system!!.particleDiameter) {
+                            val invAm = if (system!!.flagsBuffer.data!![a] and ParticleType.wallParticle != 0)
                                 0f
                             else
-                                system!!.particleInvMass!!
+                                system!!.particleInvMass
                             val rpx = ap.x - bp.x
                             val rpy = ap.y - bp.y
                             val rpn = rpx * n.y - rpy * n.x
-                            if (system!!.m_bodyContactCount >= system!!.m_bodyContactCapacity) {
-                                val oldCapacity = system!!.m_bodyContactCapacity
-                                val newCapacity = if (system!!.m_bodyContactCount != 0)
-                                    2 * system!!.m_bodyContactCount
+                            if (system!!.bodyContactCount >= system!!.bodyContactCapacity) {
+                                val oldCapacity = system!!.bodyContactCapacity
+                                val newCapacity = if (system!!.bodyContactCount != 0)
+                                    2 * system!!.bodyContactCount
                                 else
                                     Settings.minParticleBufferCapacity
-                                system!!.m_bodyContactBuffer = BufferUtils.reallocateBuffer({ ParticleBodyContact() },
-                                        system!!.m_bodyContactBuffer, oldCapacity, newCapacity)
-                                system!!.m_bodyContactCapacity = newCapacity
+                                system!!.bodyContactBuffer = BufferUtils.reallocateBuffer(
+                                    { ParticleBodyContact() },
+                                    system!!.bodyContactBuffer, oldCapacity, newCapacity
+                                )
+                                system!!.bodyContactCapacity = newCapacity
                             }
-                            val contact = system!!.m_bodyContactBuffer[system!!.m_bodyContactCount]
+                            val contact = system!!.bodyContactBuffer[system!!.bodyContactCount]
                             contact.index = a
                             contact.body = b
-                            contact.weight = 1 - d * system!!.m_inverseDiameter
+                            contact.weight = 1 - d * system!!.inverseDiameter
                             contact.normal.x = -n.x
                             contact.normal.y = -n.y
                             contact.mass = 1 / (invAm + invBm + invBI * rpn * rpn)
-                            system!!.m_bodyContactCount++
+                            system!!.bodyContactCount++
                         }
                     }
                 }
@@ -1903,48 +1931,49 @@ class ParticleSystem(internal var m_world: World) {
         private val tempVec2 = Vec2()
 
         override fun reportFixture(fixture: Fixture): Boolean {
-            if (fixture.isSensor) {
-                return true
-            }
-            val shape = fixture.getShape()
-            val body = fixture.getBody()
+            if (fixture.isSensor) return true
+            val shape = fixture.shape
+            val body = fixture.body
             val childCount = shape!!.getChildCount()
             for (childIndex in 0 until childCount) {
                 val aabb = fixture.getAABB(childIndex)
-                val aabblowerBoundx = aabb.lowerBound.x - system!!.m_particleDiameter
-                val aabblowerBoundy = aabb.lowerBound.y - system!!.m_particleDiameter
-                val aabbupperBoundx = aabb.upperBound.x + system!!.m_particleDiameter
-                val aabbupperBoundy = aabb.upperBound.y + system!!.m_particleDiameter
+                val aabblowerBoundx = aabb.lowerBound.x - system!!.particleDiameter
+                val aabblowerBoundy = aabb.lowerBound.y - system!!.particleDiameter
+                val aabbupperBoundx = aabb.upperBound.x + system!!.particleDiameter
+                val aabbupperBoundy = aabb.upperBound.y + system!!.particleDiameter
                 val firstProxy = lowerBound(
-                        system!!.m_proxyBuffer,
-                        system!!.m_proxyCount,
-                        computeTag(system!!.m_inverseDiameter * aabblowerBoundx, system!!.m_inverseDiameter * aabblowerBoundy))
+                    system!!.proxyBuffer,
+                    system!!.proxyCount,
+                    computeTag(system!!.inverseDiameter * aabblowerBoundx, system!!.inverseDiameter * aabblowerBoundy)
+                )
                 val lastProxy = upperBound(
-                        system!!.m_proxyBuffer,
-                        system!!.m_proxyCount,
-                        computeTag(system!!.m_inverseDiameter * aabbupperBoundx, system!!.m_inverseDiameter * aabbupperBoundy))
+                    system!!.proxyBuffer,
+                    system!!.proxyCount,
+                    computeTag(system!!.inverseDiameter * aabbupperBoundx, system!!.inverseDiameter * aabbupperBoundy)
+                )
 
                 for (proxy in firstProxy until lastProxy) {
-                    val a = system!!.m_proxyBuffer[proxy].index
-                    val ap = system!!.m_positionBuffer.data!![a]
+                    val a = system!!.proxyBuffer[proxy].index
+                    val ap = system!!.positionBuffer.data!![a]
                     if (aabblowerBoundx <= ap.x && ap.x <= aabbupperBoundx && aabblowerBoundy <= ap.y
-                            && ap.y <= aabbupperBoundy) {
-                        val av = system!!.m_velocityBuffer.data!![a]
+                        && ap.y <= aabbupperBoundy
+                    ) {
+                        val av = system!!.velocityBuffer.data!![a]
                         val temp = tempVec
-                        Transform.mulTransToOutUnsafe(body!!.m_xf0, ap, temp)
-                        Transform.mulToOutUnsafe(body.m_xf, temp, input.p1)
+                        Transform.mulTransToOutUnsafe(body!!.xf0, ap, temp)
+                        Transform.mulToOutUnsafe(body.xf, temp, input.p1)
                         input.p2.x = ap.x + step!!.dt * av.x
                         input.p2.y = ap.y + step!!.dt * av.y
                         input.maxFraction = 1f
                         if (fixture.raycast(output, input, childIndex)) {
                             val p = tempVec
                             p.x = ((1 - output.fraction) * input.p1.x + output.fraction * input.p2.x
-                                    + Settings.linearSlop * output.normal.x)
+                                + Settings.linearSlop * output.normal.x)
                             p.y = ((1 - output.fraction) * input.p1.y + output.fraction * input.p2.y
-                                    + Settings.linearSlop * output.normal.y)
+                                + Settings.linearSlop * output.normal.y)
 
-                            val vx = step!!.inv_dt * (p.x - ap.x)
-                            val vy = step!!.inv_dt * (p.y - ap.y)
+                            val vx = step!!.invDt * (p.x - ap.x)
+                            val vy = step!!.invDt * (p.y - ap.y)
                             av.x = vx
                             av.y = vy
                             val particleMass = system!!.particleMass
@@ -1988,11 +2017,13 @@ class ParticleSystem(internal var m_world: World) {
 
     companion object {
         /** All particle types that require creating pairs  */
-        private val k_pairFlags = ParticleType.b2_springParticle
+        private val pairFlags = ParticleType.springParticle
+
         /** All particle types that require creating triads  */
-        private val k_triadFlags = ParticleType.b2_elasticParticle
+        private val triadFlags = ParticleType.elasticParticle
+
         /** All particle types that require computing depth  */
-        private val k_noPressureFlags = ParticleType.b2_powderParticle
+        private val noPressureFlags = ParticleType.powderParticle
 
         internal val xTruncBits = 12
         internal val yTruncBits = 12
@@ -2054,18 +2085,26 @@ class ParticleSystem(internal var m_world: World) {
         }
 
         // reallocate a buffer
-        internal fun <T : Any> reallocateBuffer(buffer: ParticleBuffer<T>, oldCapacity: Int, newCapacity: Int,
-                                          deferred: Boolean): Array<T>? {
+        internal fun <T : Any> reallocateBuffer(
+            buffer: ParticleBuffer<T>, oldCapacity: Int, newCapacity: Int,
+            deferred: Boolean
+        ): Array<T>? {
             assert(newCapacity > oldCapacity)
-            return BufferUtils.reallocateBuffer(buffer.dataClass, buffer.data, buffer.userSuppliedCapacity,
-                    oldCapacity, newCapacity, deferred)
+            return BufferUtils.reallocateBuffer(
+                buffer.dataClass, buffer.data, buffer.userSuppliedCapacity,
+                oldCapacity, newCapacity, deferred
+            )
         }
 
-        internal fun reallocateBuffer(buffer: ParticleBufferInt, oldCapacity: Int, newCapacity: Int,
-                                      deferred: Boolean): IntArray? {
+        internal fun reallocateBuffer(
+            buffer: ParticleBufferInt, oldCapacity: Int, newCapacity: Int,
+            deferred: Boolean
+        ): IntArray? {
             assert(newCapacity > oldCapacity)
-            return BufferUtils.reallocateBuffer(buffer.data, buffer.userSuppliedCapacity, oldCapacity,
-                    newCapacity, deferred)
+            return BufferUtils.reallocateBuffer(
+                buffer.data, buffer.userSuppliedCapacity, oldCapacity,
+                newCapacity, deferred
+            )
         }
     }
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/particle/ParticleType.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/particle/ParticleType.kt
@@ -7,32 +7,32 @@ package org.jbox2d.particle
  */
 object ParticleType {
 
-    val b2_waterParticle = 0
+    val waterParticle = 0
+
     /** removed after next step  */
+    val zombieParticle = 1 shl 1
 
-    val b2_zombieParticle = 1 shl 1
     /** zero velocity  */
+    val wallParticle = 1 shl 2
 
-    val b2_wallParticle = 1 shl 2
     /** with restitution from stretching  */
+    val springParticle = 1 shl 3
 
-    val b2_springParticle = 1 shl 3
     /** with restitution from deformation  */
+    val elasticParticle = 1 shl 4
 
-    val b2_elasticParticle = 1 shl 4
     /** with viscosity  */
+    val viscousParticle = 1 shl 5
 
-    val b2_viscousParticle = 1 shl 5
     /** without isotropic pressure  */
+    val powderParticle = 1 shl 6
 
-    val b2_powderParticle = 1 shl 6
     /** with surface tension  */
+    val tensileParticle = 1 shl 7
 
-    val b2_tensileParticle = 1 shl 7
     /** mixing color between contacting particles  */
+    val colorMixingParticle = 1 shl 8
 
-    val b2_colorMixingParticle = 1 shl 8
     /** call b2DestructionListener on destruction  */
-
-    val b2_destructionListener = 1 shl 9
+    val destructionListener = 1 shl 9
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/particle/StackQueue.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/particle/StackQueue.kt
@@ -2,43 +2,40 @@ package org.jbox2d.particle
 
 import org.jbox2d.internal.*
 
-
 class StackQueue<T> {
 
-    private var m_buffer: Array<T>? = null
-    private var m_front: Int = 0
-    private var m_back: Int = 0
-    private var m_end: Int = 0
+    private var buffer: Array<T>? = null
+    private var front: Int = 0
+    private var back: Int = 0
+    private var end: Int = 0
 
     fun reset(buffer: Array<T>) {
-        m_buffer = buffer
-        m_front = 0
-        m_back = 0
-        m_end = buffer.size
+        this.buffer = buffer
+        front = 0
+        back = 0
+        end = buffer.size
     }
 
     fun push(task: T) {
-        if (m_back >= m_end) {
-            arraycopy(m_buffer!!, m_front, m_buffer!!, 0, m_back - m_front)
-            m_back -= m_front
-            m_front = 0
-            if (m_back >= m_end) {
-                return
-            }
+        if (back >= end) {
+            arraycopy(buffer!!, front, buffer!!, 0, back - front)
+            back -= front
+            front = 0
+            if (back >= end) return
         }
-        m_buffer!![m_back++] = task
+        buffer!![back++] = task
     }
 
     fun pop(): T {
-        assert(m_front < m_back)
-        return m_buffer!![m_front++]
+        assert(front < back)
+        return buffer!![front++]
     }
 
     fun empty(): Boolean {
-        return m_front >= m_back
+        return front >= back
     }
 
     fun front(): T {
-        return m_buffer!![m_front]
+        return buffer!![front]
     }
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/particle/VoronoiDiagram.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/particle/VoronoiDiagram.kt
@@ -7,12 +7,12 @@ import org.jbox2d.pooling.normal.MutableStack
 
 class VoronoiDiagram(generatorCapacity: Int) {
 
-    private val m_generatorBuffer: Array<Generator> = Array(generatorCapacity) { Generator() }
-    private var m_generatorCount: Int = 0
-    private var m_countX: Int = 0
-    private var m_countY: Int = 0
+    private val generatorBuffer: Array<Generator> = Array(generatorCapacity) { Generator() }
+    private var generatorCount: Int = 0
+    private var countX: Int = 0
+    private var countY: Int = 0
     // The diagram is an array of "pointers".
-    private var m_diagram: Array<Generator?>? = null
+    private var diagram: Array<Generator?>? = null
 
     private val lower = Vec2()
     private val upper = Vec2()
@@ -34,7 +34,7 @@ class VoronoiDiagram(generatorCapacity: Int) {
 
     val taskPool: VoronoiDiagramTaskMutableStack = VoronoiDiagramTaskMutableStack()
 
-    class VoronoiDiagramTaskMutableStack : MutableStack<VoronoiDiagram.VoronoiDiagramTask>(50) {
+    class VoronoiDiagramTaskMutableStack : MutableStack<VoronoiDiagramTask>(50) {
         override fun newInstance(): VoronoiDiagramTask = VoronoiDiagramTask()
         override fun newArray(size: Int): Array<VoronoiDiagramTask> =
             arrayOfNulls<VoronoiDiagramTask>(size) as Array<VoronoiDiagramTask>
@@ -48,25 +48,25 @@ class VoronoiDiagram(generatorCapacity: Int) {
     }
 
     class VoronoiDiagramTask {
-        internal var m_x: Int = 0
-        internal var m_y: Int = 0
-        internal var m_i: Int = 0
-        internal var m_generator: Generator? = null
+        internal var x: Int = 0
+        internal var y: Int = 0
+        internal var i: Int = 0
+        internal var generator: Generator? = null
 
         constructor() {}
 
         constructor(x: Int, y: Int, i: Int, g: Generator) {
-            m_x = x
-            m_y = y
-            m_i = i
-            m_generator = g
+            this.x = x
+            this.y = y
+            this.i = i
+            generator = g
         }
 
         fun set(x: Int, y: Int, i: Int, g: Generator): VoronoiDiagramTask {
-            m_x = x
-            m_y = y
-            m_i = i
-            m_generator = g
+            this.x = x
+            this.y = y
+            this.i = i
+            generator = g
             return this
         }
     }
@@ -76,13 +76,13 @@ class VoronoiDiagram(generatorCapacity: Int) {
     }
 
     fun getNodes(callback: VoronoiDiagramCallback) {
-        for (y in 0 until m_countY - 1) {
-            for (x in 0 until m_countX - 1) {
-                val i = x + y * m_countX
-                val a = m_diagram!![i]
-                val b = m_diagram!![i + 1]
-                val c = m_diagram!![i + m_countX]
-                val d = m_diagram!![i + 1 + m_countX]
+        for (y in 0 until countY - 1) {
+            for (x in 0 until countX - 1) {
+                val i = x + y * countX
+                val a = diagram!![i]
+                val b = diagram!![i + 1]
+                val c = diagram!![i + countX]
+                val d = diagram!![i + 1 + countX]
                 if (b !== c) {
                     if (a !== b && a !== c) {
                         callback.callback(a!!.tag, b!!.tag, c!!.tag)
@@ -96,121 +96,119 @@ class VoronoiDiagram(generatorCapacity: Int) {
     }
 
     fun addGenerator(center: Vec2, tag: Int) {
-        val g = m_generatorBuffer[m_generatorCount++]
+        val g = generatorBuffer[generatorCount++]
         g.center.x = center.x
         g.center.y = center.y
         g.tag = tag
     }
 
     fun generate(radius: Float) {
-        assert(m_diagram == null)
+        assert(diagram == null)
         val inverseRadius = 1 / radius
         lower.x = Float.MAX_VALUE
         lower.y = Float.MAX_VALUE
         upper.x = -Float.MAX_VALUE
         upper.y = -Float.MAX_VALUE
-        for (k in 0 until m_generatorCount) {
-            val g = m_generatorBuffer[k]
+        for (k in 0 until generatorCount) {
+            val g = generatorBuffer[k]
             Vec2.minToOut(lower, g.center, lower)
             Vec2.maxToOut(upper, g.center, upper)
         }
-        m_countX = 1 + (inverseRadius * (upper.x - lower.x)).toInt()
-        m_countY = 1 + (inverseRadius * (upper.y - lower.y)).toInt()
-        m_diagram = arrayOfNulls<Generator>(m_countX * m_countY)
-        queue.reset(arrayOfNulls<VoronoiDiagramTask>(4 * m_countX * m_countX) as Array<VoronoiDiagramTask>)
-        for (k in 0 until m_generatorCount) {
-            val g = m_generatorBuffer[k]
+        countX = 1 + (inverseRadius * (upper.x - lower.x)).toInt()
+        countY = 1 + (inverseRadius * (upper.y - lower.y)).toInt()
+        diagram = arrayOfNulls<Generator>(countX * countY)
+        queue.reset(arrayOfNulls<VoronoiDiagramTask>(4 * countX * countX) as Array<VoronoiDiagramTask>)
+        for (k in 0 until generatorCount) {
+            val g = generatorBuffer[k]
             g.center.x = inverseRadius * (g.center.x - lower.x)
             g.center.y = inverseRadius * (g.center.y - lower.y)
-            val x = MathUtils.max(0, MathUtils.min(g.center.x.toInt(), m_countX - 1))
-            val y = MathUtils.max(0, MathUtils.min(g.center.y.toInt(), m_countY - 1))
-            queue.push(taskPool.pop().set(x, y, x + y * m_countX, g))
+            val x = MathUtils.max(0, MathUtils.min(g.center.x.toInt(), countX - 1))
+            val y = MathUtils.max(0, MathUtils.min(g.center.y.toInt(), countY - 1))
+            queue.push(taskPool.pop().set(x, y, x + y * countX, g))
         }
         while (!queue.empty()) {
             val front = queue.pop()
-            val x = front.m_x
-            val y = front.m_y
-            val i = front.m_i
-            val g = front.m_generator
-            if (m_diagram!![i] == null) {
-                m_diagram!![i] = g!!
+            val x = front.x
+            val y = front.y
+            val i = front.i
+            val g = front.generator
+            if (diagram!![i] == null) {
+                diagram!![i] = g!!
                 if (x > 0) {
                     queue.push(taskPool.pop().set(x - 1, y, i - 1, g))
                 }
                 if (y > 0) {
-                    queue.push(taskPool.pop().set(x, y - 1, i - m_countX, g))
+                    queue.push(taskPool.pop().set(x, y - 1, i - countX, g))
                 }
-                if (x < m_countX - 1) {
+                if (x < countX - 1) {
                     queue.push(taskPool.pop().set(x + 1, y, i + 1, g))
                 }
-                if (y < m_countY - 1) {
-                    queue.push(taskPool.pop().set(x, y + 1, i + m_countX, g))
+                if (y < countY - 1) {
+                    queue.push(taskPool.pop().set(x, y + 1, i + countX, g))
                 }
             }
             taskPool.push(front)
         }
-        val maxIteration = m_countX + m_countY
+        val maxIteration = countX + countY
         for (iteration in 0 until maxIteration) {
-            for (y in 0 until m_countY) {
-                for (x in 0 until m_countX - 1) {
-                    val i = x + y * m_countX
-                    val a = m_diagram!![i]!!
-                    val b = m_diagram!![i + 1]!!
+            for (y in 0 until countY) {
+                for (x in 0 until countX - 1) {
+                    val i = x + y * countX
+                    val a = diagram!![i]!!
+                    val b = diagram!![i + 1]!!
                     if (a !== b) {
                         queue.push(taskPool.pop().set(x, y, i, b))
                         queue.push(taskPool.pop().set(x + 1, y, i + 1, a))
                     }
                 }
             }
-            for (y in 0 until m_countY - 1) {
-                for (x in 0 until m_countX) {
-                    val i = x + y * m_countX
-                    val a = m_diagram!![i]!!
-                    val b = m_diagram!![i + m_countX]!!
+            for (y in 0 until countY - 1) {
+                for (x in 0 until countX) {
+                    val i = x + y * countX
+                    val a = diagram!![i]!!
+                    val b = diagram!![i + countX]!!
                     if (a !== b) {
                         queue.push(taskPool.pop().set(x, y, i, b))
-                        queue.push(taskPool.pop().set(x, y + 1, i + m_countX, a))
+                        queue.push(taskPool.pop().set(x, y + 1, i + countX, a))
                     }
                 }
             }
             var updated = false
             while (!queue.empty()) {
                 val front = queue.pop()
-                val x = front.m_x
-                val y = front.m_y
-                val i = front.m_i
-                val k = front.m_generator
-                val a = m_diagram!![i]
+                val x = front.x
+                val y = front.y
+                val i = front.i
+                val k = front.generator
+                val a = diagram!![i]
                 val b = k
                 if (a !== b) {
                     val ax = a!!.center.x - x
-                    val ay = a!!.center.y - y
+                    val ay = a.center.y - y
                     val bx = b!!.center.x - x
                     val by = b.center.y - y
                     val a2 = ax * ax + ay * ay
                     val b2 = bx * bx + by * by
                     if (a2 > b2) {
-                        m_diagram!![i] = b
+                        diagram!![i] = b
                         if (x > 0) {
                             queue.push(taskPool.pop().set(x - 1, y, i - 1, b))
                         }
                         if (y > 0) {
-                            queue.push(taskPool.pop().set(x, y - 1, i - m_countX, b))
+                            queue.push(taskPool.pop().set(x, y - 1, i - countX, b))
                         }
-                        if (x < m_countX - 1) {
+                        if (x < countX - 1) {
                             queue.push(taskPool.pop().set(x + 1, y, i + 1, b))
                         }
-                        if (y < m_countY - 1) {
-                            queue.push(taskPool.pop().set(x, y + 1, i + m_countX, b))
+                        if (y < countY - 1) {
+                            queue.push(taskPool.pop().set(x, y + 1, i + countX, b))
                         }
                         updated = true
                     }
                 }
                 taskPool.push(front)
             }
-            if (!updated) {
-                break
-            }
+            if (!updated) break
         }
     }
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/pooling/IDynamicStack.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/pooling/IDynamicStack.kt
@@ -26,22 +26,18 @@ package org.jbox2d.pooling
 /**
  * Same functionality of a regular java.util stack.  Object
  * return order does not matter.
- * @author Daniel
  *
- * @param <E>
-</E> */
+ * @author Daniel
+ */
 interface IDynamicStack<E> {
 
     /**
      * Pops an item off the stack
-     * @return
      */
     fun pop(): E
 
     /**
      * Pushes an item back on the stack
-     * @param argObject
      */
     fun push(argObject: E)
-
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/pooling/IOrderedStack.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/pooling/IOrderedStack.kt
@@ -26,32 +26,27 @@ package org.jbox2d.pooling
 /**
  * This stack assumes that when you push 'n' items back,
  * you're pushing back the last 'n' items popped.
- * @author Daniel
  *
- * @param <E>
-</E> */
+ * @author Daniel
+ */
 interface IOrderedStack<E> {
 
     /**
      * Returns the next object in the pool
-     * @return
      */
     fun pop(): E
 
     /**
      * Returns the next 'argNum' objects in the pool
      * in an array
-     * @param argNum
-     * @return an array containing the next pool objects in
-     * items 0-argNum.  Array length and uniqueness not
-     * guaranteed.
+     *
+     * @return an array containing the next pool objects in items 0-argNum.
+     * Array length and uniqueness not guaranteed.
      */
     fun pop(argNum: Int): Array<E>
 
     /**
      * Tells the stack to take back the last 'argNum' items
-     * @param argNum
      */
     fun push(argNum: Int)
-
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/pooling/IWorldPool.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/pooling/IWorldPool.kt
@@ -41,17 +41,11 @@ import org.jbox2d.dynamics.contacts.Contact
 interface IWorldPool {
 
     val polyContactStack: IDynamicStack<Contact>
-
     val circleContactStack: IDynamicStack<Contact>
-
     val polyCircleContactStack: IDynamicStack<Contact>
-
     val edgeCircleContactStack: IDynamicStack<Contact>
-
     val edgePolyContactStack: IDynamicStack<Contact>
-
     val chainCircleContactStack: IDynamicStack<Contact>
-
     val chainPolyContactStack: IDynamicStack<Contact>
 
     val collision: Collision
@@ -61,40 +55,28 @@ interface IWorldPool {
     val distance: Distance
 
     fun popVec2(): Vec2
-
     fun popVec2(num: Int): Array<Vec2>
-
     fun pushVec2(num: Int)
 
     fun popVec3(): Vec3
-
     fun popVec3(num: Int): Array<Vec3>
-
     fun pushVec3(num: Int)
 
     fun popMat22(): Mat22
-
     fun popMat22(num: Int): Array<Mat22>
-
     fun pushMat22(num: Int)
 
     fun popMat33(): Mat33
-
     fun pushMat33(num: Int)
 
     fun popAABB(): AABB
-
     fun popAABB(num: Int): Array<AABB>
-
     fun pushAABB(num: Int)
 
     fun popRot(): Rot
-
     fun pushRot(num: Int)
 
     fun getFloatArray(argLength: Int): FloatArray
-
     fun getIntArray(argLength: Int): IntArray
-
     fun getVec2Array(argLength: Int): Array<Vec2>
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/pooling/arrays/Vec2ArrayPool.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/pooling/arrays/Vec2ArrayPool.kt
@@ -46,6 +46,6 @@ class Vec2ArrayPool {
     }
 
     protected fun getInitializedArray(argLength: Int): Array<Vec2> {
-        return Array<Vec2>(argLength) { Vec2() }
+        return Array(argLength) { Vec2() }
     }
 }

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/pooling/normal/DefaultWorldPool.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/pooling/normal/DefaultWorldPool.kt
@@ -92,56 +92,56 @@ class DefaultWorldPool(argSize: Int, argContainerSize: Int) : IWorldPool {
         return vecs.pop()
     }
 
-    override fun popVec2(argNum: Int): Array<Vec2> {
-        return vecs.pop(argNum)
+    override fun popVec2(num: Int): Array<Vec2> {
+        return vecs.pop(num)
     }
 
-    override fun pushVec2(argNum: Int) {
-        vecs.push(argNum)
+    override fun pushVec2(num: Int) {
+        vecs.push(num)
     }
 
     override fun popVec3(): Vec3 {
         return vec3s.pop()
     }
 
-    override fun popVec3(argNum: Int): Array<Vec3> {
-        return vec3s.pop(argNum)
+    override fun popVec3(num: Int): Array<Vec3> {
+        return vec3s.pop(num)
     }
 
-    override fun pushVec3(argNum: Int) {
-        vec3s.push(argNum)
+    override fun pushVec3(num: Int) {
+        vec3s.push(num)
     }
 
     override fun popMat22(): Mat22 {
         return mats.pop()
     }
 
-    override fun popMat22(argNum: Int): Array<Mat22> {
-        return mats.pop(argNum)
+    override fun popMat22(num: Int): Array<Mat22> {
+        return mats.pop(num)
     }
 
-    override fun pushMat22(argNum: Int) {
-        mats.push(argNum)
+    override fun pushMat22(num: Int) {
+        mats.push(num)
     }
 
     override fun popMat33(): Mat33 {
         return mat33s.pop()
     }
 
-    override fun pushMat33(argNum: Int) {
-        mat33s.push(argNum)
+    override fun pushMat33(num: Int) {
+        mat33s.push(num)
     }
 
     override fun popAABB(): AABB {
         return aabbs.pop()
     }
 
-    override fun popAABB(argNum: Int): Array<AABB> {
-        return aabbs.pop(argNum)
+    override fun popAABB(num: Int): Array<AABB> {
+        return aabbs.pop(num)
     }
 
-    override fun pushAABB(argNum: Int) {
-        aabbs.push(argNum)
+    override fun pushAABB(num: Int) {
+        aabbs.push(num)
     }
 
     override fun popRot(): Rot {

--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/pooling/stacks/DynamicIntStack.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/pooling/stacks/DynamicIntStack.kt
@@ -27,14 +27,9 @@ import org.jbox2d.internal.*
 
 class DynamicIntStack(private var size: Int) {
 
-    private var stack: IntArray? = null
+    private var stack = IntArray(size)
     var count: Int = 0
         private set
-
-    init {
-        stack = IntArray(size)
-        count = 0
-    }
 
     fun reset() {
         count = 0
@@ -42,16 +37,16 @@ class DynamicIntStack(private var size: Int) {
 
     fun pop(): Int {
         assert(count > 0)
-        return stack!![--count]
+        return stack[--count]
     }
 
     fun push(i: Int) {
         if (count == size) {
             val old = stack
             stack = IntArray(size * 2)
-            size = stack!!.size
-            arraycopy(old!!, 0, stack!!, 0, old.size)
+            size = stack.size
+            arraycopy(old, 0, stack, 0, old.size)
         }
-        stack!![count++] = i
+        stack[count++] = i
     }
 }


### PR DESCRIPTION
This PR includes many fixes, some of them are listed below:
- Remove redundant params and returns in kdocs
- Improve kdocs (wrap params in [])
- Inline init blocks where possible (indicate init value of a property right after the property declaration)
- Rename properties (remove `m_` prefix)
- Remove nullability where possible
- Simplify `assert` calls where needed